### PR TITLE
docs: update API manifest with implementation status and IaC evaluation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -222,12 +222,15 @@ Track example coverage in this section:
 - ✅ RegisteredScript
 - ✅ SiteCustomCode
 
+### TypeScript-Only Coverage (continued)
+- ✅ User
+
 ### Missing Examples
 - (None - all resources have examples!)
 
-**Current Coverage: 100% (14/14 resources with at least TypeScript examples)**
-**Multi-Language Coverage: 57% (8/14 resources with 3+ languages)**
-**Complete Coverage: 57% (8/14 resources with all 5 languages)**
+**Current Coverage: 100% (15/15 resources with at least TypeScript examples)**
+**Multi-Language Coverage: 53% (8/15 resources with 3+ languages)**
+**Complete Coverage: 53% (8/15 resources with all 5 languages)**
 
 ✅ **Target Met:** 100% of resources have at least TypeScript examples
 ✅ **Bonus:** All core resources have multi-language coverage

--- a/docs/API_IMPLEMENTATION_MANIFEST.md
+++ b/docs/API_IMPLEMENTATION_MANIFEST.md
@@ -12,111 +12,73 @@
 
 ## Implementation Status
 
-### ✅ Completed
-| Resource | Files |
-|----------|-------|
-| Site | `site_resource.go`, `site.go` |
-| Redirect | `redirect_resource.go`, `redirect.go` |
-| RobotsTxt | `robotstxt_resource.go`, `robotstxt.go` |
+### ✅ Completed (15 Resources)
+
+| Resource | Files | Description |
+|----------|-------|-------------|
+| Site | `site_resource.go`, `site.go` | Site management with publish support |
+| Redirect | `redirect_resource.go`, `redirect.go` | URL redirect rules |
+| RobotsTxt | `robotstxt_resource.go`, `robotstxt.go` | SEO robots.txt configuration |
+| Collection | `collection_resource.go`, `collection.go` | CMS collection schema |
+| CollectionField | `collectionfield_resource.go`, `collectionfield.go` | CMS collection field definitions |
+| CollectionItem | `collectionitem_resource.go`, `collectionitem.go` | CMS content items (draft/publish via isDraft) |
+| Page | `page_resource.go`, `page.go` | Static page management |
+| PageContent | `pagecontent_resource.go`, `pagecontent.go` | Page DOM content |
+| Asset | `asset_resource.go`, `asset.go` | File/image uploads |
+| AssetFolder | `assetfolder_resource.go`, `assetfolder.go` | Asset organization |
+| Webhook | `webhook_resource.go`, `webhook.go` | Event webhooks |
+| SiteCustomCode | `sitecustomcode_resource.go`, `sitecustomcode.go` | Site-level custom scripts |
+| PageCustomCode | `pagecustomcode_resource.go`, `pagecustomcode.go` | Page-level custom scripts |
+| RegisteredScript | `registeredscript_resource.go`, `registeredscript.go` | Hosted/inline script registration |
+| User | `user_resource.go`, `user.go` | Site membership users |
 
 ---
 
-## 🚀 APIs to Implement
+## 🚀 Future Candidates
 
-### Sites
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| SitePublish | POST | `/sites/{site_id}/publish` | sites:write |
-| CustomDomain | GET | `/sites/{site_id}/custom_domains` | sites:read |
+These APIs were evaluated as good IaC candidates but not yet implemented:
 
-### Pages
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Page | GET, GET | `/sites/{site_id}/pages`, `/pages/{page_id}` | pages:read |
-| PageContent | GET, PUT | `/pages/{page_id}/dom` | pages:read/write |
+### E-commerce Configuration
+| Resource | Methods | Endpoints | Scope | Notes |
+|----------|---------|-----------|-------|-------|
+| EcommerceSettings | GET | `/sites/{site_id}/ecommerce/settings` | ecommerce:read | Site-wide e-commerce configuration (payment, tax, shipping settings) |
 
-### CMS Collections
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Collection | GET, GET, POST, DELETE | `/sites/{site_id}/collections`, `/collections/{id}` | cms:read/write |
-| CollectionField | POST, PUT, DELETE | `/collections/{id}/fields` | cms:write |
-
-### CMS Items
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| CollectionItem | GET, GET, POST, PATCH, DELETE | `/collections/{id}/items` | cms:read/write |
-| CollectionItemLive | GET | `/collections/{id}/items/{item_id}/live` | cms:read |
-| CollectionItemPublish | POST | `/collections/{id}/items/publish` | cms:write |
-
-### Assets
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Asset | GET, GET, POST, DELETE | `/sites/{site_id}/assets`, `/assets/{id}` | assets:read/write |
-| AssetFolder | GET, GET, POST | `/sites/{site_id}/asset_folders` | assets:read/write |
-
-### Custom Code
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| SiteCustomCode | GET, PUT, DELETE | `/sites/{site_id}/custom_code` | custom_code:read/write |
-| PageCustomCode | GET, PUT, DELETE | `/pages/{page_id}/custom_code` | custom_code:read/write |
-| RegisteredScript | GET, POST (inline), POST (hosted) | `/sites/{site_id}/registered_scripts` | custom_code:read/write |
-
-### Forms
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Form | GET, GET | `/sites/{site_id}/forms`, `/forms/{id}` | forms:read |
-| FormSubmission | GET, GET, PATCH | `/forms/{id}/submissions` | forms:read/write |
-
-### Users & Access
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| User | GET, GET, POST, PATCH, DELETE | `/sites/{site_id}/users` | users:read/write |
-| AccessGroup | GET | `/sites/{site_id}/accessgroups` | users:read |
-
-### Webhooks
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Webhook | GET, GET, POST, DELETE | `/sites/{site_id}/webhooks`, `/webhooks/{id}` | sites:read/write |
-
-### E-commerce
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| Product | GET, GET, POST, PATCH | `/sites/{site_id}/products` | ecommerce:read/write |
-| SKU | POST, PATCH | `/sites/{site_id}/products/{id}/skus` | ecommerce:write |
-| Order | GET, GET, PATCH | `/sites/{site_id}/orders` | ecommerce:read/write |
-| OrderFulfill | POST | `/sites/{site_id}/orders/{id}/fulfill` | ecommerce:write |
-| OrderRefund | POST | `/sites/{site_id}/orders/{id}/refund` | ecommerce:write |
-| Inventory | GET, PATCH | `/collections/{id}/items/{item_id}/inventory` | ecommerce:read/write |
-| EcommerceSettings | GET | `/sites/{site_id}/ecommerce/settings` | ecommerce:read |
-
-### Meta/Token
-| Resource | Methods | Endpoints | Scope |
-|----------|---------|-----------|-------|
-| AuthorizedUser | GET | `/token/authorized_by` | authorized_user:read |
-| TokenInfo | GET | `/token/introspect` | - |
+### Provider Utilities (Data Sources)
+| Resource | Methods | Endpoints | Scope | Notes |
+|----------|---------|-----------|-------|-------|
+| TokenInfo | GET | `/token/introspect` | - | Token permission introspection for validation |
 
 ---
 
-## Recommended Implementation Batches
+## ❌ Not Suitable for IaC
 
-### Batch 1: Content Management (4 parallel agents)
-- **Agent A:** Collection + CollectionField
-- **Agent B:** CollectionItem + CollectionItemLive
-- **Agent C:** Page + PageContent
-- **Agent D:** Asset + AssetFolder
+The following Webflow APIs were evaluated and determined **not suitable** for Infrastructure-as-Code:
 
-### Batch 2: Site Configuration (3 parallel agents)
-- **Agent E:** Webhook
-- **Agent F:** SiteCustomCode + PageCustomCode
-- **Agent G:** RegisteredScript
+### Read-Only APIs (No CRUD Support)
+| API | Reason |
+|-----|--------|
+| CustomDomain | Read-only; domains managed via Webflow UI and DNS registrars |
+| Form | Read-only; forms created in Webflow designer, not via API |
+| AccessGroup | Read-only; groups defined in Webflow UI for membership tiers |
+| AuthorizedUser | Audit metadata about token creator; not infrastructure state |
 
-### Batch 3: Forms & Users (2 parallel agents)
-- **Agent H:** Form + FormSubmission
-- **Agent I:** User + AccessGroup
+### Already Covered by Existing Resources
+| API | Covered By |
+|-----|------------|
+| SitePublish | `Site` resource with `publish: true` property |
+| CollectionItemPublish | `CollectionItem` resource with `isDraft: false` property |
+| CollectionItemLive | `CollectionItem` resource exposes `lastPublished` timestamp |
 
-### Batch 4: E-commerce (2 parallel agents)
-- **Agent J:** Product + SKU + Inventory
-- **Agent K:** Order + OrderFulfill + OrderRefund
+### Application/Business Data (Not Infrastructure)
+| API | Reason |
+|-----|--------|
+| FormSubmission | User-generated form data; operational, not infrastructure |
+| Product | Business catalog data with high churn; owned by product teams |
+| SKU | Product variant data; same concerns as Product |
+| Order | Customer transaction data; temporal workflow, not idempotent |
+| OrderFulfill | Transaction action; not declarative infrastructure |
+| OrderRefund | Transaction action; not declarative infrastructure |
+| Inventory | Real-time stock levels; changes independently of IaC state |
 
 ---
 


### PR DESCRIPTION
- Update completed resources to reflect all 15 implemented resources
- Evaluate remaining Webflow APIs for IaC suitability
- Keep EcommerceSettings and TokenInfo as future candidates
- Document why 14 APIs are not suitable for IaC:
  - Read-only APIs (CustomDomain, Form, AccessGroup, AuthorizedUser)
  - Already covered (SitePublish, CollectionItemPublish/Live)
  - Application data (Product, SKU, Order, Inventory, FormSubmission)
- Update EXAMPLES.md to reflect 15/15 resource coverage