### PR TITLE
feat(sdk): enable respectSchemaVersion for C# SDK

### DIFF
--- a/provider/cmd/pulumi-resource-webflow/schema.json
+++ b/provider/cmd/pulumi-resource-webflow/schema.json
@@ -6,6 +6,7 @@
   "namespace": "webflow",
   "language": {
     "csharp": {
+      "respectSchemaVersion": true,
       "rootNamespace": "Pulumi"
     },
     "go": {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -64,7 +64,8 @@ func Provider() p.Provider {
 		}).
 		WithLanguageMap(map[string]any{
 			"csharp": map[string]any{
-				"rootNamespace": "Pulumi",
+				"rootNamespace":        "Pulumi",
+				"respectSchemaVersion": true,
 			},
 			"nodejs": map[string]any{
 				"packageName": "@jdetmar/pulumi-webflow",

--- a/sdk/dotnet/Pulumi.Webflow.csproj
+++ b/sdk/dotnet/Pulumi.Webflow.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://github.com/jdetmar/pulumi-webflow</PackageProjectUrl>
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>1.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "webflow"
+  "name": "webflow",
+  "version": "1.0.0-alpha.0+dev"
 }


### PR DESCRIPTION
## Summary
- Add `respectSchemaVersion: true` to C# language configuration in provider
- Ensures NuGet package version matches the provider schema version
- Follows best practice used by official Pulumi providers

## Test plan
- [x] `make codegen` runs successfully
- [x] All 203 provider tests pass
- [x] Linting passes with 0 issues
- [x] All SDKs build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)