### PR TITLE
fix: resolve drift detection issues and asset creation

### DIFF
--- a/.claude/skills/using-git-worktrees/SKILL.MD
+++ b/.claude/skills/using-git-worktrees/SKILL.MD
@@ -1,0 +1,217 @@
+---
+name: using-git-worktrees
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+---
+
+# Using Git Worktrees
+
+## Overview
+
+Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
+
+**Core principle:** Systematic directory selection + safety verification = reliable isolation.
+
+**Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+
+## Directory Selection Process
+
+Follow this priority order:
+
+### 1. Check Existing Directories
+
+```bash
+# Check in priority order
+ls -d .worktrees 2>/dev/null     # Preferred (hidden)
+ls -d worktrees 2>/dev/null      # Alternative
+```
+
+**If found:** Use that directory. If both exist, `.worktrees` wins.
+
+### 2. Check CLAUDE.md
+
+```bash
+grep -i "worktree.*director" CLAUDE.md 2>/dev/null
+```
+
+**If preference specified:** Use it without asking.
+
+### 3. Ask User
+
+If no directory exists and no CLAUDE.md preference:
+
+```
+No worktree directory found. Where should I create worktrees?
+
+1. .worktrees/ (project-local, hidden)
+2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
+
+Which would you prefer?
+```
+
+## Safety Verification
+
+### For Project-Local Directories (.worktrees or worktrees)
+
+**MUST verify directory is ignored before creating worktree:**
+
+```bash
+# Check if directory is ignored (respects local, global, and system gitignore)
+git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+```
+
+**If NOT ignored:**
+
+Per Jesse's rule "Fix broken things immediately":
+1. Add appropriate line to .gitignore
+2. Commit the change
+3. Proceed with worktree creation
+
+**Why critical:** Prevents accidentally committing worktree contents to repository.
+
+### For Global Directory (~/.config/superpowers/worktrees)
+
+No .gitignore verification needed - outside project entirely.
+
+## Creation Steps
+
+### 1. Detect Project Name
+
+```bash
+project=$(basename "$(git rev-parse --show-toplevel)")
+```
+
+### 2. Create Worktree
+
+```bash
+# Determine full path
+case $LOCATION in
+  .worktrees|worktrees)
+    path="$LOCATION/$BRANCH_NAME"
+    ;;
+  ~/.config/superpowers/worktrees/*)
+    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
+    ;;
+esac
+
+# Create worktree with new branch
+git worktree add "$path" -b "$BRANCH_NAME"
+cd "$path"
+```
+
+### 3. Run Project Setup
+
+Auto-detect and run appropriate setup:
+
+```bash
+# Node.js
+if [ -f package.json ]; then npm install; fi
+
+# Rust
+if [ -f Cargo.toml ]; then cargo build; fi
+
+# Python
+if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+if [ -f pyproject.toml ]; then poetry install; fi
+
+# Go
+if [ -f go.mod ]; then go mod download; fi
+```
+
+### 4. Verify Clean Baseline
+
+Run tests to ensure worktree starts clean:
+
+```bash
+# Examples - use project-appropriate command
+npm test
+cargo test
+pytest
+go test ./...
+```
+
+**If tests fail:** Report failures, ask whether to proceed or investigate.
+
+**If tests pass:** Report ready.
+
+### 5. Report Location
+
+```
+Worktree ready at <full-path>
+Tests passing (<N> tests, 0 failures)
+Ready to implement <feature-name>
+```
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| `.worktrees/` exists | Use it (verify ignored) |
+| `worktrees/` exists | Use it (verify ignored) |
+| Both exist | Use `.worktrees/` |
+| Neither exists | Check CLAUDE.md → Ask user |
+| Directory not ignored | Add to .gitignore + commit |
+| Tests fail during baseline | Report failures + ask |
+| No package.json/Cargo.toml | Skip dependency install |
+
+## Common Mistakes
+
+### Skipping ignore verification
+
+- **Problem:** Worktree contents get tracked, pollute git status
+- **Fix:** Always use `git check-ignore` before creating project-local worktree
+
+### Assuming directory location
+
+- **Problem:** Creates inconsistency, violates project conventions
+- **Fix:** Follow priority: existing > CLAUDE.md > ask
+
+### Proceeding with failing tests
+
+- **Problem:** Can't distinguish new bugs from pre-existing issues
+- **Fix:** Report failures, get explicit permission to proceed
+
+### Hardcoding setup commands
+
+- **Problem:** Breaks on projects using different tools
+- **Fix:** Auto-detect from project files (package.json, etc.)
+
+## Example Workflow
+
+```
+You: I'm using the using-git-worktrees skill to set up an isolated workspace.
+
+[Check .worktrees/ - exists]
+[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
+[Create worktree: git worktree add .worktrees/auth -b feature/auth]
+[Run npm install]
+[Run npm test - 47 passing]
+
+Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Tests passing (47 tests, 0 failures)
+Ready to implement auth feature
+```
+
+## Red Flags
+
+**Never:**
+- Create worktree without verifying it's ignored (project-local)
+- Skip baseline test verification
+- Proceed with failing tests without asking
+- Assume directory location when ambiguous
+- Skip CLAUDE.md check
+
+**Always:**
+- Follow directory priority: existing > CLAUDE.md > ask
+- Verify directory is ignored for project-local
+- Auto-detect and run project setup
+- Verify clean test baseline
+
+## Integration
+
+**Called by:**
+- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- Any skill needing isolated workspace
+
+**Pairs with:**
+- **finishing-a-development-branch** - REQUIRED for cleanup after work complete
+- **executing-plans** or **subagent-driven-development** - Work happens in this worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,20 @@ The Makefile automatically runs the post-processing script after Java SDK genera
 make test_provider
 ```
 
+### Local Provider Testing
+
+To test provider changes with a real Pulumi stack:
+
+```bash
+# Build and install the provider locally
+make provider && install -m 755 bin/pulumi-resource-webflow ~/.pulumi/plugins/resource-webflow-v1.0.0-alpha.0/
+
+# Test with your stack
+cd /path/to/your/stack && pulumi preview --diff
+```
+
+**IMPORTANT:** Use `install` instead of `cp` when copying the provider binary. On macOS, `cp` preserves certain extended attributes that cause the binary to be killed by the OS security system, resulting in "exit status -1" errors.
+
 ## Project Structure
 
 ```

--- a/provider/asset.go
+++ b/provider/asset.go
@@ -448,8 +448,9 @@ func PostAssetUploadURL(
 			continue
 		}
 
-		// Handle error responses (accept both 200 and 201 as success)
-		if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		// Handle error responses (accept 200, 201, and 202 as success)
+		// 202 Accepted is returned when asset is registered for async upload to S3
+		if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 {
 			return nil, handleWebflowError(resp.StatusCode, body)
 		}
 

--- a/provider/cmd/pulumi-resource-webflow/schema.json
+++ b/provider/cmd/pulumi-resource-webflow/schema.json
@@ -925,6 +925,10 @@
           "type": "string",
           "description": "The timestamp when the script was last updated (RFC3339 format). This is automatically updated by Webflow when the script is modified and is read-only."
         },
+        "scriptId": {
+          "type": "string",
+          "description": "The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources."
+        },
         "siteId": {
           "type": "string",
           "description": "The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls."

--- a/provider/collectionitem_resource.go
+++ b/provider/collectionitem_resource.go
@@ -155,7 +155,10 @@ func (c *CollectionItemResource) Diff(
 	}
 
 	// Check for cmsLocaleId change (can be updated in place)
-	if req.State.CmsLocaleID != req.Inputs.CmsLocaleID {
+	// Only report change if user explicitly specified it.
+	// An empty input means "I don't care about this field" not "remove it".
+	// This prevents phantom updates when API returns a value user didn't set.
+	if req.Inputs.CmsLocaleID != "" && req.State.CmsLocaleID != req.Inputs.CmsLocaleID {
 		detailedDiff["cmsLocaleId"] = p.PropertyDiff{Kind: p.Update}
 		diff.HasChanges = true
 	}

--- a/provider/redirect_resource.go
+++ b/provider/redirect_resource.go
@@ -132,7 +132,9 @@ func (r *Redirect) Diff(
 	}
 
 	// Check for statusCode change (requires replacement due to Webflow API limitation)
-	if req.State.StatusCode != req.Inputs.StatusCode {
+	// Only report change if state has valid statusCode that differs from inputs.
+	// The Webflow API list endpoint doesn't return statusCode, so it comes back as 0.
+	if req.State.StatusCode != 0 && req.State.StatusCode != req.Inputs.StatusCode {
 		diff.DeleteBeforeReplace = true
 		diff.HasChanges = true
 		diff.DetailedDiff = map[string]p.PropertyDiff{

--- a/provider/site_resource.go
+++ b/provider/site_resource.go
@@ -216,7 +216,10 @@ func (r *SiteResource) Diff(
 		}
 	}
 
-	if req.Inputs.ShortName != req.State.ShortName {
+	// Only report shortName change if user explicitly specified it.
+	// An empty input means "I don't care about this field" not "remove it".
+	// This prevents phantom updates when API returns a value user didn't set.
+	if req.Inputs.ShortName != "" && req.Inputs.ShortName != req.State.ShortName {
 		diff.HasChanges = true
 		diff.DetailedDiff["shortName"] = p.PropertyDiff{
 			Kind: p.Update,

--- a/sdk/dotnet/Webflow/RegisteredScript.cs
+++ b/sdk/dotnet/Webflow/RegisteredScript.cs
@@ -53,6 +53,12 @@ namespace Community.Pulumi.Webflow
         public Output<string?> LastUpdated { get; private set; } = null!;
 
         /// <summary>
+        /// The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+        /// </summary>
+        [Output("scriptId")]
+        public Output<string?> ScriptId { get; private set; } = null!;
+
+        /// <summary>
         /// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         /// </summary>
         [Output("siteId")]

--- a/sdk/go/webflow/registeredScript.go
+++ b/sdk/go/webflow/registeredScript.go
@@ -28,6 +28,8 @@ type RegisteredScript struct {
 	IntegrityHash pulumi.StringOutput `pulumi:"integrityHash"`
 	// The timestamp when the script was last updated (RFC3339 format). This is automatically updated by Webflow when the script is modified and is read-only.
 	LastUpdated pulumi.StringPtrOutput `pulumi:"lastUpdated"`
+	// The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+	ScriptId pulumi.StringPtrOutput `pulumi:"scriptId"`
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringOutput `pulumi:"siteId"`
 	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
@@ -181,6 +183,11 @@ func (o RegisteredScriptOutput) IntegrityHash() pulumi.StringOutput {
 // The timestamp when the script was last updated (RFC3339 format). This is automatically updated by Webflow when the script is modified and is read-only.
 func (o RegisteredScriptOutput) LastUpdated() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *RegisteredScript) pulumi.StringPtrOutput { return v.LastUpdated }).(pulumi.StringPtrOutput)
+}
+
+// The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+func (o RegisteredScriptOutput) ScriptId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RegisteredScript) pulumi.StringPtrOutput { return v.ScriptId }).(pulumi.StringPtrOutput)
 }
 
 // The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
@@ -105,6 +105,20 @@ public class RegisteredScript extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.lastUpdated);
     }
     /**
+     * The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+     * 
+     */
+    @Export(name="scriptId", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> scriptId;
+
+    /**
+     * @return The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+     * 
+     */
+    public Output<Optional<String>> scriptId() {
+        return Codegen.optional(this.scriptId);
+    }
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      * 
      */

--- a/sdk/nodejs/registeredScript.ts
+++ b/sdk/nodejs/registeredScript.ts
@@ -59,6 +59,10 @@ export class RegisteredScript extends pulumi.CustomResource {
      */
     declare public /*out*/ readonly lastUpdated: pulumi.Output<string | undefined>;
     /**
+     * The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+     */
+    declare public /*out*/ readonly scriptId: pulumi.Output<string | undefined>;
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      */
     declare public readonly siteId: pulumi.Output<string>;
@@ -98,6 +102,7 @@ export class RegisteredScript extends pulumi.CustomResource {
             resourceInputs["version"] = args?.version;
             resourceInputs["createdOn"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
+            resourceInputs["scriptId"] = undefined /*out*/;
         } else {
             resourceInputs["canCopy"] = undefined /*out*/;
             resourceInputs["createdOn"] = undefined /*out*/;
@@ -105,6 +110,7 @@ export class RegisteredScript extends pulumi.CustomResource {
             resourceInputs["hostedLocation"] = undefined /*out*/;
             resourceInputs["integrityHash"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
+            resourceInputs["scriptId"] = undefined /*out*/;
             resourceInputs["siteId"] = undefined /*out*/;
             resourceInputs["version"] = undefined /*out*/;
         }

--- a/sdk/python/pulumi_webflow/registered_script.py
+++ b/sdk/python/pulumi_webflow/registered_script.py
@@ -196,6 +196,7 @@ class RegisteredScript(pulumi.CustomResource):
             __props__.__dict__["version"] = version
             __props__.__dict__["created_on"] = None
             __props__.__dict__["last_updated"] = None
+            __props__.__dict__["script_id"] = None
         super(RegisteredScript, __self__).__init__(
             'webflow:index:RegisteredScript',
             resource_name,
@@ -224,6 +225,7 @@ class RegisteredScript(pulumi.CustomResource):
         __props__.__dict__["hosted_location"] = None
         __props__.__dict__["integrity_hash"] = None
         __props__.__dict__["last_updated"] = None
+        __props__.__dict__["script_id"] = None
         __props__.__dict__["site_id"] = None
         __props__.__dict__["version"] = None
         return RegisteredScript(resource_name, opts=opts, __props__=__props__)
@@ -275,6 +277,14 @@ class RegisteredScript(pulumi.CustomResource):
         The timestamp when the script was last updated (RFC3339 format). This is automatically updated by Webflow when the script is modified and is read-only.
         """
         return pulumi.get(self, "last_updated")
+
+    @_builtins.property
+    @pulumi.getter(name="scriptId")
+    def script_id(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
+        """
+        return pulumi.get(self, "script_id")
 
     @_builtins.property
     @pulumi.getter(name="siteId")


### PR DESCRIPTION
## Summary

- Fix phantom drift detection for multiple resources where API responses don't include all fields
- Add `scriptId` output to RegisteredScript resource for referencing in SiteCustomCode
- Fix Asset creation to handle HTTP 202 Accepted response from Webflow API
- Document local provider testing workflow with macOS security workaround

## Changes

### Drift Detection Fixes
| Resource | Field | Issue | Fix |
|----------|-------|-------|-----|
| Redirect | `statusCode` | `0 => 301` drift | Only report change if state has non-zero value |
| Site | `shortName` | API-assigned value caused drift | Only report change if user specified value |
| CollectionItem | `cmsLocaleId` | API-assigned value caused drift | Only report change if user specified value |
| RegisteredScript | `version` | `"1.0.0" => "1.0.0"` drift | Only report change if input is non-empty |

### New Features
- **RegisteredScript.scriptId**: New output field exposing the Webflow-assigned script ID for use in SiteCustomCode scripts array

### Bug Fixes
- **Asset creation**: Accept HTTP 202 Accepted response (async S3 upload registration)

### Documentation
- Added local provider testing section to CLAUDE.md
- Documented `install` vs `cp` workaround for macOS security issues

## Test plan
- [x] Unit tests added for all drift detection fixes
- [x] Unit test added for Asset 202 Accepted response
- [x] Full test suite passes (`make test_provider`)
- [x] Integration tested with real Pulumi stack - 12 resources with no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)