### PR TITLE
fix(registeredscript): resolve version diff detection issue

### DIFF
--- a/provider/cmd/pulumi-resource-webflow/schema.json
+++ b/provider/cmd/pulumi-resource-webflow/schema.json
@@ -942,8 +942,7 @@
         "siteId",
         "displayName",
         "hostedLocation",
-        "integrityHash",
-        "version"
+        "integrityHash"
       ],
       "inputProperties": {
         "canCopy": {
@@ -975,8 +974,7 @@
         "siteId",
         "displayName",
         "hostedLocation",
-        "integrityHash",
-        "version"
+        "integrityHash"
       ]
     },
     "webflow:index:RobotsTxt": {

--- a/sdk/dotnet/Webflow/RegisteredScript.cs
+++ b/sdk/dotnet/Webflow/RegisteredScript.cs
@@ -68,7 +68,7 @@ namespace Community.Pulumi.Webflow
         /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         /// </summary>
         [Output("version")]
-        public Output<string> Version { get; private set; } = null!;
+        public Output<string?> Version { get; private set; } = null!;
 
 
         /// <summary>
@@ -148,8 +148,8 @@ namespace Community.Pulumi.Webflow
         /// <summary>
         /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         /// </summary>
-        [Input("version", required: true)]
-        public Input<string> Version { get; set; } = null!;
+        [Input("version")]
+        public Input<string>? Version { get; set; }
 
         public RegisteredScriptArgs()
         {

--- a/sdk/go/webflow/registeredScript.go
+++ b/sdk/go/webflow/registeredScript.go
@@ -33,7 +33,7 @@ type RegisteredScript struct {
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringOutput `pulumi:"siteId"`
 	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringOutput `pulumi:"version"`
+	Version pulumi.StringPtrOutput `pulumi:"version"`
 }
 
 // NewRegisteredScript registers a new resource with the given unique name, arguments, and options.
@@ -54,9 +54,6 @@ func NewRegisteredScript(ctx *pulumi.Context,
 	}
 	if args.SiteId == nil {
 		return nil, errors.New("invalid value for required argument 'SiteId'")
-	}
-	if args.Version == nil {
-		return nil, errors.New("invalid value for required argument 'Version'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource RegisteredScript
@@ -102,7 +99,7 @@ type registeredScriptArgs struct {
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId string `pulumi:"siteId"`
 	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version string `pulumi:"version"`
+	Version *string `pulumi:"version"`
 }
 
 // The set of arguments for constructing a RegisteredScript resource.
@@ -118,7 +115,7 @@ type RegisteredScriptArgs struct {
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringInput
 	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringInput
+	Version pulumi.StringPtrInput
 }
 
 func (RegisteredScriptArgs) ElementType() reflect.Type {
@@ -199,8 +196,8 @@ func (o RegisteredScriptOutput) SiteId() pulumi.StringOutput {
 }
 
 // The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-func (o RegisteredScriptOutput) Version() pulumi.StringOutput {
-	return o.ApplyT(func(v *RegisteredScript) pulumi.StringOutput { return v.Version }).(pulumi.StringOutput)
+func (o RegisteredScriptOutput) Version() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RegisteredScript) pulumi.StringPtrOutput { return v.Version }).(pulumi.StringPtrOutput)
 }
 
 func init() {

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
@@ -137,14 +137,14 @@ public class RegisteredScript extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="version", refs={String.class}, tree="[0]")
-    private Output<String> version;
+    private Output</* @Nullable */ String> version;
 
     /**
      * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
      * 
      */
-    public Output<String> version() {
-        return this.version;
+    public Output<Optional<String>> version() {
+        return Codegen.optional(this.version);
     }
 
     /**

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScriptArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScriptArgs.java
@@ -96,15 +96,15 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
      * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
      * 
      */
-    @Import(name="version", required=true)
-    private Output<String> version;
+    @Import(name="version")
+    private @Nullable Output<String> version;
 
     /**
      * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
      * 
      */
-    public Output<String> version() {
-        return this.version;
+    public Optional<Output<String>> version() {
+        return Optional.ofNullable(this.version);
     }
 
     private RegisteredScriptArgs() {}
@@ -247,7 +247,7 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
          * @return builder
          * 
          */
-        public Builder version(Output<String> version) {
+        public Builder version(@Nullable Output<String> version) {
             $.version = version;
             return this;
         }
@@ -274,9 +274,6 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
             }
             if ($.siteId == null) {
                 throw new MissingRequiredPropertyException("RegisteredScriptArgs", "siteId");
-            }
-            if ($.version == null) {
-                throw new MissingRequiredPropertyException("RegisteredScriptArgs", "version");
             }
             return $;
         }

--- a/sdk/nodejs/registeredScript.ts
+++ b/sdk/nodejs/registeredScript.ts
@@ -69,7 +69,7 @@ export class RegisteredScript extends pulumi.CustomResource {
     /**
      * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
      */
-    declare public readonly version: pulumi.Output<string>;
+    declare public readonly version: pulumi.Output<string | undefined>;
 
     /**
      * Create a RegisteredScript resource with the given unique name, arguments, and options.
@@ -93,9 +93,6 @@ export class RegisteredScript extends pulumi.CustomResource {
             }
             if (args?.siteId === undefined && !opts.urn) {
                 throw new Error("Missing required property 'siteId'");
-            }
-            if (args?.version === undefined && !opts.urn) {
-                throw new Error("Missing required property 'version'");
             }
             resourceInputs["canCopy"] = args?.canCopy;
             resourceInputs["displayName"] = args?.displayName;
@@ -149,5 +146,5 @@ export interface RegisteredScriptArgs {
     /**
      * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
      */
-    version: pulumi.Input<string>;
+    version?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_webflow/registered_script.py
+++ b/sdk/python/pulumi_webflow/registered_script.py
@@ -23,24 +23,25 @@ class RegisteredScriptArgs:
                  hosted_location: pulumi.Input[_builtins.str],
                  integrity_hash: pulumi.Input[_builtins.str],
                  site_id: pulumi.Input[_builtins.str],
-                 version: pulumi.Input[_builtins.str],
-                 can_copy: Optional[pulumi.Input[_builtins.bool]] = None):
+                 can_copy: Optional[pulumi.Input[_builtins.bool]] = None,
+                 version: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a RegisteredScript resource.
         :param pulumi.Input[_builtins.str] display_name: The user-facing name for the script (1-50 alphanumeric characters). This name is used to identify the script in the Webflow interface. Only letters (A-Z, a-z) and numbers (0-9) are allowed. Example valid names: 'CmsSlider', 'AnalyticsScript', 'MyCustomScript123'.
         :param pulumi.Input[_builtins.str] hosted_location: The URI for the externally hosted script (e.g., 'https://cdn.example.com/my-script.js'). Must be a valid HTTP or HTTPS URL. The script should be publicly accessible and properly configured for cross-origin requests.
         :param pulumi.Input[_builtins.str] integrity_hash: The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
         :param pulumi.Input[_builtins.str] site_id: The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
-        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         :param pulumi.Input[_builtins.bool] can_copy: Indicates whether the script can be copied when the site is duplicated. Default: false. When true, the script will be included when creating a copy of the site.
+        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """
         pulumi.set(__self__, "display_name", display_name)
         pulumi.set(__self__, "hosted_location", hosted_location)
         pulumi.set(__self__, "integrity_hash", integrity_hash)
         pulumi.set(__self__, "site_id", site_id)
-        pulumi.set(__self__, "version", version)
         if can_copy is not None:
             pulumi.set(__self__, "can_copy", can_copy)
+        if version is not None:
+            pulumi.set(__self__, "version", version)
 
     @_builtins.property
     @pulumi.getter(name="displayName")
@@ -91,18 +92,6 @@ class RegisteredScriptArgs:
         pulumi.set(self, "site_id", value)
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Input[_builtins.str]:
-        """
-        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        """
-        return pulumi.get(self, "version")
-
-    @version.setter
-    def version(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "version", value)
-
-    @_builtins.property
     @pulumi.getter(name="canCopy")
     def can_copy(self) -> Optional[pulumi.Input[_builtins.bool]]:
         """
@@ -113,6 +102,18 @@ class RegisteredScriptArgs:
     @can_copy.setter
     def can_copy(self, value: Optional[pulumi.Input[_builtins.bool]]):
         pulumi.set(self, "can_copy", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def version(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        """
+        return pulumi.get(self, "version")
+
+    @version.setter
+    def version(self, value: Optional[pulumi.Input[_builtins.str]]):
+        pulumi.set(self, "version", value)
 
 
 @pulumi.type_token("webflow:index:RegisteredScript")
@@ -192,8 +193,6 @@ class RegisteredScript(pulumi.CustomResource):
             if site_id is None and not opts.urn:
                 raise TypeError("Missing required property 'site_id'")
             __props__.__dict__["site_id"] = site_id
-            if version is None and not opts.urn:
-                raise TypeError("Missing required property 'version'")
             __props__.__dict__["version"] = version
             __props__.__dict__["created_on"] = None
             __props__.__dict__["last_updated"] = None
@@ -297,7 +296,7 @@ class RegisteredScript(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def version(self) -> pulumi.Output[_builtins.str]:
+    def version(self) -> pulumi.Output[Optional[_builtins.str]]:
         """
         The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """


### PR DESCRIPTION
## Summary

This fixes an issue where RegisteredScript would always detect a version diff even when the version hadn't changed, causing unnecessary replacements that broke SiteCustomCode (Issue 2).

**Root cause:** Pulumi's struct embedding doesn't properly deserialize the version field into the embedded `RegisteredScriptResourceArgs` struct, causing `req.State.Version` to be empty during Diff comparison.

**Changes:**
- Made version field optional in struct tag for backwards compatibility with existing state (Create still validates version is provided)
- Updated Diff method to only compare version when both state and inputs have non-empty values

## Test plan

- [x] Unit tests pass (`make test_provider`)
- [x] Live API testing confirms:
  - RegisteredScript no longer falsely detects version diffs
  - SiteCustomCode works correctly with RegisteredScript
  - `siteCustomCodeUpdated` output shows valid timestamp

## Related Issues

Updates ISSUES-TO-FIX.md:
- Issue 1 (RegisteredScript Update 404): ✅ Already fixed in PR #51
- Issue 2 (SiteCustomCode Script ID Format): ✅ Resolved by this PR (was blocked by Issue 4)
- Issue 4 (RegisteredScript Version Diff): ✅ Fixed by this PR
- Issue 5 (Asset Variants Parsing): ❌ New issue documented
- Issue 6 (CollectionItem Slug Uniqueness): ❌ New issue documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)