### PR TITLE
fix(examples): correct package references for C#, Go, and Java

### DIFF
--- a/examples/asset/csharp/Webflow.Asset.csproj
+++ b/examples/asset/csharp/Webflow.Asset.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/asset/go/go.mod
+++ b/examples/asset/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/asset
+module github.com/JDetmar/pulumi-webflow/examples/asset
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/asset/java/pom.xml
+++ b/examples/asset/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/collection/csharp/Webflow.Collection.csproj
+++ b/examples/collection/csharp/Webflow.Collection.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/collection/go/go.mod
+++ b/examples/collection/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/collection
+module github.com/JDetmar/pulumi-webflow/examples/collection
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/collection/java/pom.xml
+++ b/examples/collection/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/collectionitem/csharp/Webflow.CollectionItem.csproj
+++ b/examples/collectionitem/csharp/Webflow.CollectionItem.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/collectionitem/go/go.mod
+++ b/examples/collectionitem/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/collectionitem
+module github.com/JDetmar/pulumi-webflow/examples/collectionitem
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/collectionitem/java/pom.xml
+++ b/examples/collectionitem/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/page/go/go.mod
+++ b/examples/page/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/page
+module github.com/JDetmar/pulumi-webflow/examples/page
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/quickstart/go/go.mod
+++ b/examples/quickstart/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/quickstart/go
+module github.com/JDetmar/pulumi-webflow/examples/quickstart/go
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/redirect/csharp/Webflow.Redirect.csproj
+++ b/examples/redirect/csharp/Webflow.Redirect.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/redirect/go/go.mod
+++ b/examples/redirect/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/redirect
+module github.com/JDetmar/pulumi-webflow/examples/redirect
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/redirect/java/pom.xml
+++ b/examples/redirect/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/robotstxt/csharp/Webflow.RobotsTxt.csproj
+++ b/examples/robotstxt/csharp/Webflow.RobotsTxt.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/robotstxt/go/go.mod
+++ b/examples/robotstxt/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/robotstxt
+module github.com/JDetmar/pulumi-webflow/examples/robotstxt
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/robotstxt/java/pom.xml
+++ b/examples/robotstxt/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/site/csharp/Webflow.Site.csproj
+++ b/examples/site/csharp/Webflow.Site.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.0.0" />
-    <PackageReference Include="Pulumi.Webflow" Version="1.0.0-alpha.0" />
+    <PackageReference Include="Community.Pulumi.Webflow" Version="0.9.0" />
   </ItemGroup>
 </Project>

--- a/examples/site/go/go.mod
+++ b/examples/site/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/site
+module github.com/JDetmar/pulumi-webflow/examples/site
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/site/java/pom.xml
+++ b/examples/site/java/pom.xml
@@ -28,8 +28,8 @@
             <version>${pulumi.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.pulumi</groupId>
-            <artifactId>webflow</artifactId>
+            <groupId>io.github.jdetmar</groupId>
+            <artifactId>pulumi-webflow</artifactId>
             <version>${webflow.version}</version>
         </dependency>
     </dependencies>

--- a/examples/stack-config/go-advanced/go.mod
+++ b/examples/stack-config/go-advanced/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/stack-config/go-advanced
+module github.com/JDetmar/pulumi-webflow/examples/stack-config/go-advanced
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 

--- a/examples/troubleshooting-logs/go-log-analysis/go.mod
+++ b/examples/troubleshooting-logs/go-log-analysis/go.mod
@@ -1,7 +1,7 @@
-module github.com/jdetmar/pulumi-webflow/examples/troubleshooting-logs/go-log-analysis
+module github.com/JDetmar/pulumi-webflow/examples/troubleshooting-logs/go-log-analysis
 
 go 1.21
 
 require github.com/pulumi/pulumi/sdk/v3 v3.100.0
 
-replace github.com/jdetmar/pulumi-webflow/sdk/go/webflow => ../../../sdk/go
+replace github.com/JDetmar/pulumi-webflow/sdk/go/webflow => ../../../sdk/go

--- a/examples/webhook/go/go.mod
+++ b/examples/webhook/go/go.mod
@@ -1,11 +1,11 @@
-module github.com/jdetmar/pulumi-webflow/examples/webhook
+module github.com/JDetmar/pulumi-webflow/examples/webhook
 
 go 1.24.7
 
 toolchain go1.24.11
 
 require (
-	github.com/jdetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
+	github.com/JDetmar/pulumi-webflow/sdk/go/webflow v0.0.1-alpha.1
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0
 )
 


### PR DESCRIPTION
Update package references in examples to match published packages:
- C#: Change from Pulumi.Webflow to Community.Pulumi.Webflow v0.9.0
- Go: Fix case sensitivity from github.com/jdetmar to github.com/JDetmar
- Java: Change from com.pulumi:webflow to io.github.jdetmar:pulumi-webflow

Fixes #69

Generated with [Claude Code](https://claude.ai/code)