### PR TITLE
fix(provider): add pluginDownloadURL for automatic provider installation

### DIFF
--- a/provider/cmd/pulumi-resource-webflow/schema.json
+++ b/provider/cmd/pulumi-resource-webflow/schema.json
@@ -4,6 +4,7 @@
   "description": "Unofficial community-maintained Pulumi provider for managing Webflow sites, redirects, and robots.txt. Not affiliated with Pulumi Corporation or Webflow, Inc.",
   "homepage": "https://github.com/JDetmar/pulumi-webflow",
   "repository": "https://github.com/JDetmar/pulumi-webflow",
+  "pluginDownloadURL": "github://api.github.com/JDetmar/pulumi-webflow",
   "namespace": "webflow",
   "language": {
     "csharp": {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,6 +36,7 @@ func Provider() p.Provider {
 		).
 		WithHomepage("https://github.com/JDetmar/pulumi-webflow").
 		WithRepository("https://github.com/JDetmar/pulumi-webflow").
+		WithPluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow").
 		WithNamespace(Name).
 		WithConfig(infer.Config(&Config{})).
 		WithResources(

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -53,6 +53,7 @@ namespace Community.Pulumi.Webflow
         {
             var dst = src ?? new global::Pulumi.InvokeOptions{};
             dst.Version = src?.Version ?? Version;
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "github://api.github.com/JDetmar/pulumi-webflow";
             return dst;
         }
 
@@ -60,6 +61,7 @@ namespace Community.Pulumi.Webflow
         {
             var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
             dst.Version = src?.Version ?? Version;
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "github://api.github.com/JDetmar/pulumi-webflow";
             return dst;
         }
 

--- a/sdk/dotnet/Webflow/Asset.cs
+++ b/sdk/dotnet/Webflow/Asset.cs
@@ -123,6 +123,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/AssetFolder.cs
+++ b/sdk/dotnet/Webflow/AssetFolder.cs
@@ -81,6 +81,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/Collection.cs
+++ b/sdk/dotnet/Webflow/Collection.cs
@@ -81,6 +81,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/CollectionField.cs
+++ b/sdk/dotnet/Webflow/CollectionField.cs
@@ -93,6 +93,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/CollectionItem.cs
+++ b/sdk/dotnet/Webflow/CollectionItem.cs
@@ -93,6 +93,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/EcommerceSettings.cs
+++ b/sdk/dotnet/Webflow/EcommerceSettings.cs
@@ -57,6 +57,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/PageContent.cs
+++ b/sdk/dotnet/Webflow/PageContent.cs
@@ -59,6 +59,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/PageCustomCode.cs
+++ b/sdk/dotnet/Webflow/PageCustomCode.cs
@@ -63,6 +63,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/PageData.cs
+++ b/sdk/dotnet/Webflow/PageData.cs
@@ -111,6 +111,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/Provider.cs
+++ b/sdk/dotnet/Webflow/Provider.cs
@@ -37,6 +37,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
                 AdditionalSecretOutputs =
                 {
                     "apiToken",

--- a/sdk/dotnet/Webflow/Redirect.cs
+++ b/sdk/dotnet/Webflow/Redirect.cs
@@ -69,6 +69,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/RegisteredScript.cs
+++ b/sdk/dotnet/Webflow/RegisteredScript.cs
@@ -93,6 +93,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/RobotsTxt.cs
+++ b/sdk/dotnet/Webflow/RobotsTxt.cs
@@ -57,6 +57,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/Site.cs
+++ b/sdk/dotnet/Webflow/Site.cs
@@ -117,6 +117,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/SiteCustomCode.cs
+++ b/sdk/dotnet/Webflow/SiteCustomCode.cs
@@ -63,6 +63,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/User.cs
+++ b/sdk/dotnet/Webflow/User.cs
@@ -105,6 +105,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Webflow/Webhook.cs
+++ b/sdk/dotnet/Webflow/Webhook.cs
@@ -75,6 +75,7 @@ namespace Community.Pulumi.Webflow
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                PluginDownloadURL = "github://api.github.com/JDetmar/pulumi-webflow",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,6 @@
 {
   "resource": true,
   "name": "webflow",
-  "version": "1.0.0-alpha.0+dev"
+  "version": "1.0.0-alpha.0+dev",
+  "server": "github://api.github.com/JDetmar/pulumi-webflow"
 }

--- a/sdk/go/webflow/internal/pulumiUtilities.go
+++ b/sdk/go/webflow/internal/pulumiUtilities.go
@@ -164,7 +164,7 @@ func callPlainInner(
 // PkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
-
+	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
@@ -175,7 +175,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 // PkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
-
+	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))

--- a/sdk/go/webflow/pulumi-plugin.json
+++ b/sdk/go/webflow/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "webflow"
+  "name": "webflow",
+  "server": "github://api.github.com/JDetmar/pulumi-webflow"
 }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Asset.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Asset.java
@@ -257,6 +257,7 @@ public class Asset extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/AssetFolder.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/AssetFolder.java
@@ -158,6 +158,7 @@ public class AssetFolder extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Collection.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Collection.java
@@ -157,6 +157,7 @@ public class Collection extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/CollectionField.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/CollectionField.java
@@ -188,6 +188,7 @@ public class CollectionField extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/CollectionItem.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/CollectionItem.java
@@ -188,6 +188,7 @@ public class CollectionItem extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/EcommerceSettings.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/EcommerceSettings.java
@@ -101,6 +101,7 @@ public class EcommerceSettings extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageContent.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageContent.java
@@ -105,6 +105,7 @@ public class PageContent extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageCustomCode.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageCustomCode.java
@@ -117,6 +117,7 @@ public class PageCustomCode extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageData.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/PageData.java
@@ -230,6 +230,7 @@ public class PageData extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Provider.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Provider.java
@@ -66,6 +66,7 @@ public class Provider extends com.pulumi.resources.ProviderResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .additionalSecretOutputs(List.of(
                 "apiToken"
             ))

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Redirect.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Redirect.java
@@ -130,6 +130,7 @@ public class Redirect extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
@@ -186,6 +186,7 @@ public class RegisteredScript extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RobotsTxt.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RobotsTxt.java
@@ -100,6 +100,7 @@ public class RobotsTxt extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Site.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Site.java
@@ -243,6 +243,7 @@ public class Site extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/SiteCustomCode.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/SiteCustomCode.java
@@ -117,6 +117,7 @@ public class SiteCustomCode extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/User.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/User.java
@@ -215,6 +215,7 @@ public class User extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Webhook.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/Webhook.java
@@ -145,6 +145,7 @@ public class Webhook extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .pluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -17,6 +17,7 @@
     "pulumi": {
         "resource": true,
         "name": "webflow",
-        "version": "1.0.0-alpha.0+dev"
+        "version": "1.0.0-alpha.0+dev",
+        "server": "github://api.github.com/JDetmar/pulumi-webflow"
     }
 }

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -53,7 +53,7 @@ export function getVersion(): string {
 
 /** @internal */
 export function resourceOptsDefaults(): any {
-    return { version: getVersion() };
+    return { version: getVersion(), pluginDownloadURL: "github://api.github.com/JDetmar/pulumi-webflow" };
 }
 
 /** @internal */

--- a/sdk/python/pulumi_webflow/_utilities.py
+++ b/sdk/python/pulumi_webflow/_utilities.py
@@ -325,7 +325,7 @@ def deprecated(message: str) -> typing.Callable[[C], C]:
     return decorator
 
 def get_plugin_download_url():
-	return None
+	return "github://api.github.com/JDetmar/pulumi-webflow"
 
 def get_version():
      return _version_str

--- a/sdk/python/pulumi_webflow/pulumi-plugin.json
+++ b/sdk/python/pulumi_webflow/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "webflow"
+  "name": "webflow",
+  "server": "github://api.github.com/JDetmar/pulumi-webflow"
 }

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
-VERSION = "0.0.0"
+VERSION = "1.0.0-alpha.0+dev"
 def readme():
     try:
         with open('README.md', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary

- Adds `WithPluginDownloadURL("github://api.github.com/JDetmar/pulumi-webflow")` to the provider schema
- Enables automatic provider binary downloads from GitHub releases instead of the Pulumi registry

## Problem

Users were experiencing errors when Pulumi tried to download the provider from the official Pulumi registry, which doesn't host this community provider. Without the `pluginDownloadURL` in the schema, Pulumi defaults to looking in the wrong location.

## Solution

Added `pluginDownloadURL` to the provider schema, which propagates to all SDK metadata files (`pulumi-plugin.json`, `package.json`, etc.) during codegen. Now Pulumi will automatically download the correct provider binary from GitHub releases.

## Test plan

- [x] `make codegen` completed successfully
- [x] All 441 tests pass
- [x] Lint passes with 0 issues
- [x] Verified `pluginDownloadURL` appears in schema.json and all SDK plugin metadata files

🤖 Generated with [Claude Code](https://claude.com/claude-code)