### PR TITLE
fix!: rename version to scriptVersion to avoid framework collision

### DIFF
--- a/provider/cmd/pulumi-resource-webflow/schema.json
+++ b/provider/cmd/pulumi-resource-webflow/schema.json
@@ -55,7 +55,7 @@
           "type": "string",
           "description": "The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded."
         },
-        "version": {
+        "scriptVersion": {
           "type": "string",
           "description": "The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied."
         }
@@ -63,7 +63,7 @@
       "type": "object",
       "required": [
         "id",
-        "version",
+        "scriptVersion",
         "location"
       ]
     },
@@ -201,7 +201,7 @@
           "type": "string",
           "description": "Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded."
         },
-        "version": {
+        "scriptVersion": {
           "type": "string",
           "description": "The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered."
         }
@@ -209,7 +209,7 @@
       "type": "object",
       "required": [
         "id",
-        "version",
+        "scriptVersion",
         "location",
         "attributes"
       ]
@@ -717,6 +717,10 @@
           "type": "string",
           "description": "The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources."
         },
+        "scriptVersion": {
+          "type": "string",
+          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
+        },
         "siteId": {
           "type": "string",
           "description": "The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls."
@@ -724,16 +728,12 @@
         "sourceCode": {
           "type": "string",
           "description": "The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead."
-        },
-        "version": {
-          "type": "string",
-          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
         }
       },
       "required": [
         "siteId",
         "sourceCode",
-        "version",
+        "scriptVersion",
         "displayName",
         "scriptId"
       ],
@@ -750,6 +750,10 @@
           "type": "string",
           "description": "The Sub-Resource Integrity (SRI) hash for the script (optional). Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/"
         },
+        "scriptVersion": {
+          "type": "string",
+          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
+        },
         "siteId": {
           "type": "string",
           "description": "The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls."
@@ -757,16 +761,12 @@
         "sourceCode": {
           "type": "string",
           "description": "The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead."
-        },
-        "version": {
-          "type": "string",
-          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
         }
       },
       "requiredInputs": [
         "siteId",
         "sourceCode",
-        "version",
+        "scriptVersion",
         "displayName"
       ]
     },
@@ -1014,13 +1014,13 @@
           "type": "string",
           "description": "The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources."
         },
+        "scriptVersion": {
+          "type": "string",
+          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
+        },
         "siteId": {
           "type": "string",
           "description": "The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls."
-        },
-        "version": {
-          "type": "string",
-          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
         }
       },
       "required": [
@@ -1047,13 +1047,13 @@
           "type": "string",
           "description": "The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/"
         },
+        "scriptVersion": {
+          "type": "string",
+          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
+        },
         "siteId": {
           "type": "string",
           "description": "The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls."
-        },
-        "version": {
-          "type": "string",
-          "description": "The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning."
         }
       },
       "requiredInputs": [

--- a/provider/inlinescript_resource.go
+++ b/provider/inlinescript_resource.go
@@ -30,7 +30,7 @@ type InlineScriptArgs struct {
 	SourceCode string `pulumi:"sourceCode"`
 	// Version is the Semantic Version (SemVer) string for the script.
 	// Format: "major.minor.patch" (e.g., "1.0.0", "2.3.1")
-	Version string `pulumi:"version"`
+	Version string `pulumi:"scriptVersion"`
 	// DisplayName is the user-facing name for the script (1-50 alphanumeric characters).
 	// Example: "CmsSlider", "AnalyticsScript", "MyCustomScript123"
 	DisplayName string `pulumi:"displayName"`
@@ -158,7 +158,7 @@ func (r *InlineScript) Diff(
 	stateVersion := req.State.Version
 	inputVersion := req.Inputs.Version
 	if stateVersion != "" && inputVersion != "" && stateVersion != inputVersion {
-		detailedDiff["version"] = p.PropertyDiff{Kind: p.UpdateReplace}
+		detailedDiff["scriptVersion"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 
 	if req.State.CanCopy != req.Inputs.CanCopy {

--- a/provider/inlinescript_resource_test.go
+++ b/provider/inlinescript_resource_test.go
@@ -563,7 +563,7 @@ func TestInlineScriptDiff_SameVersion_NoChange(t *testing.T) {
 	}
 
 	if diffResp.DetailedDiff != nil {
-		if _, hasVersion := diffResp.DetailedDiff["version"]; hasVersion {
+		if _, hasVersion := diffResp.DetailedDiff["scriptVersion"]; hasVersion {
 			t.Errorf("Diff() incorrectly flagged version for change when values are identical")
 		}
 	}
@@ -664,7 +664,7 @@ func TestInlineScriptDiff_ChangesRequireReplacement(t *testing.T) {
 			modifyFn: func(args *InlineScriptArgs) {
 				args.Version = "2.0.0"
 			},
-			fieldName: "version",
+			fieldName: "scriptVersion",
 		},
 		{
 			name: "canCopy change",

--- a/provider/pagecustomcode_resource.go
+++ b/provider/pagecustomcode_resource.go
@@ -27,7 +27,7 @@ type PageCustomCodeScript struct {
 	ID string `pulumi:"id"`
 	// Version is the semantic version string for the registered script (required).
 	// Example: "1.0.0" or "2.5.3"
-	Version string `pulumi:"version"`
+	Version string `pulumi:"scriptVersion"`
 	// Location is where the script should be applied (required).
 	// Must be either "header" (loaded before body closes) or "footer" (loaded at end of page).
 	Location string `pulumi:"location"`

--- a/provider/registeredscript_resource.go
+++ b/provider/registeredscript_resource.go
@@ -41,7 +41,7 @@ type RegisteredScriptResourceArgs struct {
 	// See https://semver.org/ for more information.
 	// Note: Marked optional for backwards compatibility with existing state, but
 	// Create validates that version is provided for new resources.
-	Version string `pulumi:"version,optional"`
+	Version string `pulumi:"scriptVersion,optional"`
 	// CanCopy indicates whether the script can be copied on site duplication.
 	// Default: false
 	CanCopy bool `pulumi:"canCopy,optional"`
@@ -158,7 +158,7 @@ func (r *RegisteredScriptResource) Diff(
 	stateVersion := req.State.Version
 	inputVersion := req.Inputs.Version
 	if stateVersion != "" && inputVersion != "" && stateVersion != inputVersion {
-		detailedDiff["version"] = p.PropertyDiff{Kind: p.UpdateReplace}
+		detailedDiff["scriptVersion"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 
 	if req.State.CanCopy != req.Inputs.CanCopy {

--- a/provider/registeredscript_resource_test.go
+++ b/provider/registeredscript_resource_test.go
@@ -611,7 +611,7 @@ func TestRegisteredScriptDiff_SameVersion_NoChange(t *testing.T) {
 	}
 
 	if diffResp.DetailedDiff != nil {
-		if _, hasVersion := diffResp.DetailedDiff["version"]; hasVersion {
+		if _, hasVersion := diffResp.DetailedDiff["scriptVersion"]; hasVersion {
 			t.Errorf("Diff() incorrectly flagged version for change when values are identical")
 		}
 	}
@@ -718,7 +718,7 @@ func TestRegisteredScriptDiff_ChangesRequireReplacement(t *testing.T) {
 			modifyFn: func(args *RegisteredScriptResourceArgs) {
 				args.Version = "2.0.0"
 			},
-			fieldName: "version",
+			fieldName: "scriptVersion",
 		},
 		{
 			name: "canCopy change",

--- a/provider/sitecustomcode_resource.go
+++ b/provider/sitecustomcode_resource.go
@@ -29,7 +29,7 @@ type CustomScriptArgs struct {
 	ID string `pulumi:"id"`
 	// Version is the semantic version string for the registered script (e.g., "1.0.0").
 	// This version must exist for the registered script.
-	Version string `pulumi:"version"`
+	Version string `pulumi:"scriptVersion"`
 	// Location is where the script is placed on the page.
 	// Valid values: "header" (placed in <head>) or "footer" (placed before </body>).
 	Location string `pulumi:"location"`

--- a/sdk/dotnet/Webflow/InlineScript.cs
+++ b/sdk/dotnet/Webflow/InlineScript.cs
@@ -59,6 +59,12 @@ namespace Community.Pulumi.Webflow
         public Output<string> ScriptId { get; private set; } = null!;
 
         /// <summary>
+        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        /// </summary>
+        [Output("scriptVersion")]
+        public Output<string> ScriptVersion { get; private set; } = null!;
+
+        /// <summary>
         /// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         /// </summary>
         [Output("siteId")]
@@ -69,12 +75,6 @@ namespace Community.Pulumi.Webflow
         /// </summary>
         [Output("sourceCode")]
         public Output<string> SourceCode { get; private set; } = null!;
-
-        /// <summary>
-        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        /// </summary>
-        [Output("version")]
-        public Output<string> Version { get; private set; } = null!;
 
 
         /// <summary>
@@ -141,6 +141,12 @@ namespace Community.Pulumi.Webflow
         public Input<string>? IntegrityHash { get; set; }
 
         /// <summary>
+        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        /// </summary>
+        [Input("scriptVersion", required: true)]
+        public Input<string> ScriptVersion { get; set; } = null!;
+
+        /// <summary>
         /// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         /// </summary>
         [Input("siteId", required: true)]
@@ -151,12 +157,6 @@ namespace Community.Pulumi.Webflow
         /// </summary>
         [Input("sourceCode", required: true)]
         public Input<string> SourceCode { get; set; } = null!;
-
-        /// <summary>
-        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        /// </summary>
-        [Input("version", required: true)]
-        public Input<string> Version { get; set; } = null!;
 
         public InlineScriptArgs()
         {

--- a/sdk/dotnet/Webflow/Inputs/CustomScriptArgsArgs.cs
+++ b/sdk/dotnet/Webflow/Inputs/CustomScriptArgsArgs.cs
@@ -40,8 +40,8 @@ namespace Community.Pulumi.Webflow.Inputs
         /// <summary>
         /// The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         /// </summary>
-        [Input("version", required: true)]
-        public Input<string> Version { get; set; } = null!;
+        [Input("scriptVersion", required: true)]
+        public Input<string> ScriptVersion { get; set; } = null!;
 
         public CustomScriptArgsArgs()
         {

--- a/sdk/dotnet/Webflow/Inputs/PageCustomCodeScriptArgs.cs
+++ b/sdk/dotnet/Webflow/Inputs/PageCustomCodeScriptArgs.cs
@@ -40,8 +40,8 @@ namespace Community.Pulumi.Webflow.Inputs
         /// <summary>
         /// The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         /// </summary>
-        [Input("version", required: true)]
-        public Input<string> Version { get; set; } = null!;
+        [Input("scriptVersion", required: true)]
+        public Input<string> ScriptVersion { get; set; } = null!;
 
         public PageCustomCodeScriptArgs()
         {

--- a/sdk/dotnet/Webflow/Outputs/CustomScriptArgs.cs
+++ b/sdk/dotnet/Webflow/Outputs/CustomScriptArgs.cs
@@ -29,7 +29,7 @@ namespace Community.Pulumi.Webflow.Outputs
         /// <summary>
         /// The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         /// </summary>
-        public readonly string Version;
+        public readonly string ScriptVersion;
 
         [OutputConstructor]
         private CustomScriptArgs(
@@ -39,12 +39,12 @@ namespace Community.Pulumi.Webflow.Outputs
 
             string location,
 
-            string version)
+            string scriptVersion)
         {
             Attributes = attributes;
             Id = id;
             Location = location;
-            Version = version;
+            ScriptVersion = scriptVersion;
         }
     }
 }

--- a/sdk/dotnet/Webflow/Outputs/PageCustomCodeScript.cs
+++ b/sdk/dotnet/Webflow/Outputs/PageCustomCodeScript.cs
@@ -29,7 +29,7 @@ namespace Community.Pulumi.Webflow.Outputs
         /// <summary>
         /// The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         /// </summary>
-        public readonly string Version;
+        public readonly string ScriptVersion;
 
         [OutputConstructor]
         private PageCustomCodeScript(
@@ -39,12 +39,12 @@ namespace Community.Pulumi.Webflow.Outputs
 
             string location,
 
-            string version)
+            string scriptVersion)
         {
             Attributes = attributes;
             Id = id;
             Location = location;
-            Version = version;
+            ScriptVersion = scriptVersion;
         }
     }
 }

--- a/sdk/dotnet/Webflow/RegisteredScript.cs
+++ b/sdk/dotnet/Webflow/RegisteredScript.cs
@@ -59,16 +59,16 @@ namespace Community.Pulumi.Webflow
         public Output<string> ScriptId { get; private set; } = null!;
 
         /// <summary>
+        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        /// </summary>
+        [Output("scriptVersion")]
+        public Output<string?> ScriptVersion { get; private set; } = null!;
+
+        /// <summary>
         /// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         /// </summary>
         [Output("siteId")]
         public Output<string> SiteId { get; private set; } = null!;
-
-        /// <summary>
-        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        /// </summary>
-        [Output("version")]
-        public Output<string?> Version { get; private set; } = null!;
 
 
         /// <summary>
@@ -141,16 +141,16 @@ namespace Community.Pulumi.Webflow
         public Input<string> IntegrityHash { get; set; } = null!;
 
         /// <summary>
+        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        /// </summary>
+        [Input("scriptVersion")]
+        public Input<string>? ScriptVersion { get; set; }
+
+        /// <summary>
         /// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         /// </summary>
         [Input("siteId", required: true)]
         public Input<string> SiteId { get; set; } = null!;
-
-        /// <summary>
-        /// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        /// </summary>
-        [Input("version")]
-        public Input<string>? Version { get; set; }
 
         public RegisteredScriptArgs()
         {

--- a/sdk/go/webflow/inlineScript.go
+++ b/sdk/go/webflow/inlineScript.go
@@ -30,12 +30,12 @@ type InlineScript struct {
 	LastUpdated pulumi.StringPtrOutput `pulumi:"lastUpdated"`
 	// The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
 	ScriptId pulumi.StringOutput `pulumi:"scriptId"`
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion pulumi.StringOutput `pulumi:"scriptVersion"`
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringOutput `pulumi:"siteId"`
 	// The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
 	SourceCode pulumi.StringOutput `pulumi:"sourceCode"`
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringOutput `pulumi:"version"`
 }
 
 // NewInlineScript registers a new resource with the given unique name, arguments, and options.
@@ -48,14 +48,14 @@ func NewInlineScript(ctx *pulumi.Context,
 	if args.DisplayName == nil {
 		return nil, errors.New("invalid value for required argument 'DisplayName'")
 	}
+	if args.ScriptVersion == nil {
+		return nil, errors.New("invalid value for required argument 'ScriptVersion'")
+	}
 	if args.SiteId == nil {
 		return nil, errors.New("invalid value for required argument 'SiteId'")
 	}
 	if args.SourceCode == nil {
 		return nil, errors.New("invalid value for required argument 'SourceCode'")
-	}
-	if args.Version == nil {
-		return nil, errors.New("invalid value for required argument 'Version'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource InlineScript
@@ -96,12 +96,12 @@ type inlineScriptArgs struct {
 	DisplayName string `pulumi:"displayName"`
 	// The Sub-Resource Integrity (SRI) hash for the script (optional). Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
 	IntegrityHash *string `pulumi:"integrityHash"`
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion string `pulumi:"scriptVersion"`
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId string `pulumi:"siteId"`
 	// The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
 	SourceCode string `pulumi:"sourceCode"`
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version string `pulumi:"version"`
 }
 
 // The set of arguments for constructing a InlineScript resource.
@@ -112,12 +112,12 @@ type InlineScriptArgs struct {
 	DisplayName pulumi.StringInput
 	// The Sub-Resource Integrity (SRI) hash for the script (optional). Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
 	IntegrityHash pulumi.StringPtrInput
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion pulumi.StringInput
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringInput
 	// The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
 	SourceCode pulumi.StringInput
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringInput
 }
 
 func (InlineScriptArgs) ElementType() reflect.Type {
@@ -192,6 +192,11 @@ func (o InlineScriptOutput) ScriptId() pulumi.StringOutput {
 	return o.ApplyT(func(v *InlineScript) pulumi.StringOutput { return v.ScriptId }).(pulumi.StringOutput)
 }
 
+// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+func (o InlineScriptOutput) ScriptVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v *InlineScript) pulumi.StringOutput { return v.ScriptVersion }).(pulumi.StringOutput)
+}
+
 // The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 func (o InlineScriptOutput) SiteId() pulumi.StringOutput {
 	return o.ApplyT(func(v *InlineScript) pulumi.StringOutput { return v.SiteId }).(pulumi.StringOutput)
@@ -200,11 +205,6 @@ func (o InlineScriptOutput) SiteId() pulumi.StringOutput {
 // The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
 func (o InlineScriptOutput) SourceCode() pulumi.StringOutput {
 	return o.ApplyT(func(v *InlineScript) pulumi.StringOutput { return v.SourceCode }).(pulumi.StringOutput)
-}
-
-// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-func (o InlineScriptOutput) Version() pulumi.StringOutput {
-	return o.ApplyT(func(v *InlineScript) pulumi.StringOutput { return v.Version }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/go/webflow/pulumiTypes.go
+++ b/sdk/go/webflow/pulumiTypes.go
@@ -21,7 +21,7 @@ type CustomScriptArgs struct {
 	// The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded.
 	Location string `pulumi:"location"`
 	// The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
-	Version string `pulumi:"version"`
+	ScriptVersion string `pulumi:"scriptVersion"`
 }
 
 // CustomScriptArgsInput is an input type that accepts CustomScriptArgsArgs and CustomScriptArgsOutput values.
@@ -43,7 +43,7 @@ type CustomScriptArgsArgs struct {
 	// The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded.
 	Location pulumi.StringInput `pulumi:"location"`
 	// The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
-	Version pulumi.StringInput `pulumi:"version"`
+	ScriptVersion pulumi.StringInput `pulumi:"scriptVersion"`
 }
 
 func (CustomScriptArgsArgs) ElementType() reflect.Type {
@@ -113,8 +113,8 @@ func (o CustomScriptArgsOutput) Location() pulumi.StringOutput {
 }
 
 // The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
-func (o CustomScriptArgsOutput) Version() pulumi.StringOutput {
-	return o.ApplyT(func(v CustomScriptArgs) string { return v.Version }).(pulumi.StringOutput)
+func (o CustomScriptArgsOutput) ScriptVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomScriptArgs) string { return v.ScriptVersion }).(pulumi.StringOutput)
 }
 
 type CustomScriptArgsArrayOutput struct{ *pulumi.OutputState }
@@ -400,7 +400,7 @@ type PageCustomCodeScript struct {
 	// Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded.
 	Location string `pulumi:"location"`
 	// The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
-	Version string `pulumi:"version"`
+	ScriptVersion string `pulumi:"scriptVersion"`
 }
 
 // PageCustomCodeScriptInput is an input type that accepts PageCustomCodeScriptArgs and PageCustomCodeScriptOutput values.
@@ -422,7 +422,7 @@ type PageCustomCodeScriptArgs struct {
 	// Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded.
 	Location pulumi.StringInput `pulumi:"location"`
 	// The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
-	Version pulumi.StringInput `pulumi:"version"`
+	ScriptVersion pulumi.StringInput `pulumi:"scriptVersion"`
 }
 
 func (PageCustomCodeScriptArgs) ElementType() reflect.Type {
@@ -492,8 +492,8 @@ func (o PageCustomCodeScriptOutput) Location() pulumi.StringOutput {
 }
 
 // The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
-func (o PageCustomCodeScriptOutput) Version() pulumi.StringOutput {
-	return o.ApplyT(func(v PageCustomCodeScript) string { return v.Version }).(pulumi.StringOutput)
+func (o PageCustomCodeScriptOutput) ScriptVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PageCustomCodeScript) string { return v.ScriptVersion }).(pulumi.StringOutput)
 }
 
 type PageCustomCodeScriptArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/webflow/registeredScript.go
+++ b/sdk/go/webflow/registeredScript.go
@@ -30,10 +30,10 @@ type RegisteredScript struct {
 	LastUpdated pulumi.StringPtrOutput `pulumi:"lastUpdated"`
 	// The Webflow-assigned script ID (read-only). This is typically the lowercase version of displayName. Use this value when referencing the script in SiteCustomCode or PageCustomCode resources.
 	ScriptId pulumi.StringOutput `pulumi:"scriptId"`
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion pulumi.StringPtrOutput `pulumi:"scriptVersion"`
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringOutput `pulumi:"siteId"`
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringPtrOutput `pulumi:"version"`
 }
 
 // NewRegisteredScript registers a new resource with the given unique name, arguments, and options.
@@ -96,10 +96,10 @@ type registeredScriptArgs struct {
 	HostedLocation string `pulumi:"hostedLocation"`
 	// The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
 	IntegrityHash string `pulumi:"integrityHash"`
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion *string `pulumi:"scriptVersion"`
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId string `pulumi:"siteId"`
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version *string `pulumi:"version"`
 }
 
 // The set of arguments for constructing a RegisteredScript resource.
@@ -112,10 +112,10 @@ type RegisteredScriptArgs struct {
 	HostedLocation pulumi.StringInput
 	// The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
 	IntegrityHash pulumi.StringInput
+	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+	ScriptVersion pulumi.StringPtrInput
 	// The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 	SiteId pulumi.StringInput
-	// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-	Version pulumi.StringPtrInput
 }
 
 func (RegisteredScriptArgs) ElementType() reflect.Type {
@@ -190,14 +190,14 @@ func (o RegisteredScriptOutput) ScriptId() pulumi.StringOutput {
 	return o.ApplyT(func(v *RegisteredScript) pulumi.StringOutput { return v.ScriptId }).(pulumi.StringOutput)
 }
 
+// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+func (o RegisteredScriptOutput) ScriptVersion() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RegisteredScript) pulumi.StringPtrOutput { return v.ScriptVersion }).(pulumi.StringPtrOutput)
+}
+
 // The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
 func (o RegisteredScriptOutput) SiteId() pulumi.StringOutput {
 	return o.ApplyT(func(v *RegisteredScript) pulumi.StringOutput { return v.SiteId }).(pulumi.StringOutput)
-}
-
-// The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-func (o RegisteredScriptOutput) Version() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *RegisteredScript) pulumi.StringPtrOutput { return v.Version }).(pulumi.StringPtrOutput)
 }
 
 func init() {

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/InlineScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/InlineScript.java
@@ -119,6 +119,20 @@ public class InlineScript extends com.pulumi.resources.CustomResource {
         return this.scriptId;
     }
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    @Export(name="scriptVersion", refs={String.class}, tree="[0]")
+    private Output<String> scriptVersion;
+
+    /**
+     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    public Output<String> scriptVersion() {
+        return this.scriptVersion;
+    }
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      * 
      */
@@ -145,20 +159,6 @@ public class InlineScript extends com.pulumi.resources.CustomResource {
      */
     public Output<String> sourceCode() {
         return this.sourceCode;
-    }
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    @Export(name="version", refs={String.class}, tree="[0]")
-    private Output<String> version;
-
-    /**
-     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    public Output<String> version() {
-        return this.version;
     }
 
     /**

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/InlineScriptArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/InlineScriptArgs.java
@@ -63,6 +63,21 @@ public final class InlineScriptArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    @Import(name="scriptVersion", required=true)
+    private Output<String> scriptVersion;
+
+    /**
+     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    public Output<String> scriptVersion() {
+        return this.scriptVersion;
+    }
+
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      * 
      */
@@ -92,30 +107,15 @@ public final class InlineScriptArgs extends com.pulumi.resources.ResourceArgs {
         return this.sourceCode;
     }
 
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    @Import(name="version", required=true)
-    private Output<String> version;
-
-    /**
-     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    public Output<String> version() {
-        return this.version;
-    }
-
     private InlineScriptArgs() {}
 
     private InlineScriptArgs(InlineScriptArgs $) {
         this.canCopy = $.canCopy;
         this.displayName = $.displayName;
         this.integrityHash = $.integrityHash;
+        this.scriptVersion = $.scriptVersion;
         this.siteId = $.siteId;
         this.sourceCode = $.sourceCode;
-        this.version = $.version;
     }
 
     public static Builder builder() {
@@ -200,6 +200,27 @@ public final class InlineScriptArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param scriptVersion The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder scriptVersion(Output<String> scriptVersion) {
+            $.scriptVersion = scriptVersion;
+            return this;
+        }
+
+        /**
+         * @param scriptVersion The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder scriptVersion(String scriptVersion) {
+            return scriptVersion(Output.of(scriptVersion));
+        }
+
+        /**
          * @param siteId The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
          * 
          * @return builder
@@ -241,39 +262,18 @@ public final class InlineScriptArgs extends com.pulumi.resources.ResourceArgs {
             return sourceCode(Output.of(sourceCode));
         }
 
-        /**
-         * @param version The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(Output<String> version) {
-            $.version = version;
-            return this;
-        }
-
-        /**
-         * @param version The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(String version) {
-            return version(Output.of(version));
-        }
-
         public InlineScriptArgs build() {
             if ($.displayName == null) {
                 throw new MissingRequiredPropertyException("InlineScriptArgs", "displayName");
+            }
+            if ($.scriptVersion == null) {
+                throw new MissingRequiredPropertyException("InlineScriptArgs", "scriptVersion");
             }
             if ($.siteId == null) {
                 throw new MissingRequiredPropertyException("InlineScriptArgs", "siteId");
             }
             if ($.sourceCode == null) {
                 throw new MissingRequiredPropertyException("InlineScriptArgs", "sourceCode");
-            }
-            if ($.version == null) {
-                throw new MissingRequiredPropertyException("InlineScriptArgs", "version");
             }
             return $;
         }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScript.java
@@ -119,6 +119,20 @@ public class RegisteredScript extends com.pulumi.resources.CustomResource {
         return this.scriptId;
     }
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    @Export(name="scriptVersion", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> scriptVersion;
+
+    /**
+     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    public Output<Optional<String>> scriptVersion() {
+        return Codegen.optional(this.scriptVersion);
+    }
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      * 
      */
@@ -131,20 +145,6 @@ public class RegisteredScript extends com.pulumi.resources.CustomResource {
      */
     public Output<String> siteId() {
         return this.siteId;
-    }
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    @Export(name="version", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> version;
-
-    /**
-     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    public Output<Optional<String>> version() {
-        return Codegen.optional(this.version);
     }
 
     /**

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScriptArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/RegisteredScriptArgs.java
@@ -78,6 +78,21 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    @Import(name="scriptVersion")
+    private @Nullable Output<String> scriptVersion;
+
+    /**
+     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     * 
+     */
+    public Optional<Output<String>> scriptVersion() {
+        return Optional.ofNullable(this.scriptVersion);
+    }
+
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      * 
      */
@@ -92,21 +107,6 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
         return this.siteId;
     }
 
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    @Import(name="version")
-    private @Nullable Output<String> version;
-
-    /**
-     * @return The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     * 
-     */
-    public Optional<Output<String>> version() {
-        return Optional.ofNullable(this.version);
-    }
-
     private RegisteredScriptArgs() {}
 
     private RegisteredScriptArgs(RegisteredScriptArgs $) {
@@ -114,8 +114,8 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
         this.displayName = $.displayName;
         this.hostedLocation = $.hostedLocation;
         this.integrityHash = $.integrityHash;
+        this.scriptVersion = $.scriptVersion;
         this.siteId = $.siteId;
-        this.version = $.version;
     }
 
     public static Builder builder() {
@@ -221,6 +221,27 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
+         * @param scriptVersion The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder scriptVersion(@Nullable Output<String> scriptVersion) {
+            $.scriptVersion = scriptVersion;
+            return this;
+        }
+
+        /**
+         * @param scriptVersion The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder scriptVersion(String scriptVersion) {
+            return scriptVersion(Output.of(scriptVersion));
+        }
+
+        /**
          * @param siteId The Webflow site ID (24-character lowercase hexadecimal string, e.g., &#39;5f0c8c9e1c9d440000e8d8c3&#39;). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
          * 
          * @return builder
@@ -239,27 +260,6 @@ public final class RegisteredScriptArgs extends com.pulumi.resources.ResourceArg
          */
         public Builder siteId(String siteId) {
             return siteId(Output.of(siteId));
-        }
-
-        /**
-         * @param version The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(@Nullable Output<String> version) {
-            $.version = version;
-            return this;
-        }
-
-        /**
-         * @param version The Semantic Version (SemVer) string for the script (e.g., &#39;1.0.0&#39;, &#39;2.3.1&#39;). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(String version) {
-            return version(Output.of(version));
         }
 
         public RegisteredScriptArgs build() {

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/inputs/CustomScriptArgsArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/inputs/CustomScriptArgsArgs.java
@@ -67,15 +67,15 @@ public final class CustomScriptArgsArgs extends com.pulumi.resources.ResourceArg
      * The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      * 
      */
-    @Import(name="version", required=true)
-    private Output<String> version;
+    @Import(name="scriptVersion", required=true)
+    private Output<String> scriptVersion;
 
     /**
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      * 
      */
-    public Output<String> version() {
-        return this.version;
+    public Output<String> scriptVersion() {
+        return this.scriptVersion;
     }
 
     private CustomScriptArgsArgs() {}
@@ -84,7 +84,7 @@ public final class CustomScriptArgsArgs extends com.pulumi.resources.ResourceArg
         this.attributes = $.attributes;
         this.id = $.id;
         this.location = $.location;
-        this.version = $.version;
+        this.scriptVersion = $.scriptVersion;
     }
 
     public static Builder builder() {
@@ -169,24 +169,24 @@ public final class CustomScriptArgsArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param version The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
+         * @param scriptVersion The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
          * 
          * @return builder
          * 
          */
-        public Builder version(Output<String> version) {
-            $.version = version;
+        public Builder scriptVersion(Output<String> scriptVersion) {
+            $.scriptVersion = scriptVersion;
             return this;
         }
 
         /**
-         * @param version The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
+         * @param scriptVersion The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
          * 
          * @return builder
          * 
          */
-        public Builder version(String version) {
-            return version(Output.of(version));
+        public Builder scriptVersion(String scriptVersion) {
+            return scriptVersion(Output.of(scriptVersion));
         }
 
         public CustomScriptArgsArgs build() {
@@ -196,8 +196,8 @@ public final class CustomScriptArgsArgs extends com.pulumi.resources.ResourceArg
             if ($.location == null) {
                 throw new MissingRequiredPropertyException("CustomScriptArgsArgs", "location");
             }
-            if ($.version == null) {
-                throw new MissingRequiredPropertyException("CustomScriptArgsArgs", "version");
+            if ($.scriptVersion == null) {
+                throw new MissingRequiredPropertyException("CustomScriptArgsArgs", "scriptVersion");
             }
             return $;
         }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/inputs/PageCustomCodeScriptArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/inputs/PageCustomCodeScriptArgs.java
@@ -65,15 +65,15 @@ public final class PageCustomCodeScriptArgs extends com.pulumi.resources.Resourc
      * The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      * 
      */
-    @Import(name="version", required=true)
-    private Output<String> version;
+    @Import(name="scriptVersion", required=true)
+    private Output<String> scriptVersion;
 
     /**
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      * 
      */
-    public Output<String> version() {
-        return this.version;
+    public Output<String> scriptVersion() {
+        return this.scriptVersion;
     }
 
     private PageCustomCodeScriptArgs() {}
@@ -82,7 +82,7 @@ public final class PageCustomCodeScriptArgs extends com.pulumi.resources.Resourc
         this.attributes = $.attributes;
         this.id = $.id;
         this.location = $.location;
-        this.version = $.version;
+        this.scriptVersion = $.scriptVersion;
     }
 
     public static Builder builder() {
@@ -167,24 +167,24 @@ public final class PageCustomCodeScriptArgs extends com.pulumi.resources.Resourc
         }
 
         /**
-         * @param version The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
+         * @param scriptVersion The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
          * 
          * @return builder
          * 
          */
-        public Builder version(Output<String> version) {
-            $.version = version;
+        public Builder scriptVersion(Output<String> scriptVersion) {
+            $.scriptVersion = scriptVersion;
             return this;
         }
 
         /**
-         * @param version The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
+         * @param scriptVersion The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
          * 
          * @return builder
          * 
          */
-        public Builder version(String version) {
-            return version(Output.of(version));
+        public Builder scriptVersion(String scriptVersion) {
+            return scriptVersion(Output.of(scriptVersion));
         }
 
         public PageCustomCodeScriptArgs build() {
@@ -197,8 +197,8 @@ public final class PageCustomCodeScriptArgs extends com.pulumi.resources.Resourc
             if ($.location == null) {
                 throw new MissingRequiredPropertyException("PageCustomCodeScriptArgs", "location");
             }
-            if ($.version == null) {
-                throw new MissingRequiredPropertyException("PageCustomCodeScriptArgs", "version");
+            if ($.scriptVersion == null) {
+                throw new MissingRequiredPropertyException("PageCustomCodeScriptArgs", "scriptVersion");
             }
             return $;
         }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/outputs/CustomScriptArgs.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/outputs/CustomScriptArgs.java
@@ -32,7 +32,7 @@ public final class CustomScriptArgs {
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      * 
      */
-    private String version;
+    private String scriptVersion;
 
     private CustomScriptArgs() {}
     /**
@@ -60,8 +60,8 @@ public final class CustomScriptArgs {
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;, &#39;0.1.2&#39;). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      * 
      */
-    public String version() {
-        return this.version;
+    public String scriptVersion() {
+        return this.scriptVersion;
     }
 
     public static Builder builder() {
@@ -76,14 +76,14 @@ public final class CustomScriptArgs {
         private @Nullable Map<String,Object> attributes;
         private String id;
         private String location;
-        private String version;
+        private String scriptVersion;
         public Builder() {}
         public Builder(CustomScriptArgs defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.attributes = defaults.attributes;
     	      this.id = defaults.id;
     	      this.location = defaults.location;
-    	      this.version = defaults.version;
+    	      this.scriptVersion = defaults.scriptVersion;
         }
 
         @CustomType.Setter
@@ -109,11 +109,11 @@ public final class CustomScriptArgs {
             return this;
         }
         @CustomType.Setter
-        public Builder version(String version) {
-            if (version == null) {
-              throw new MissingRequiredPropertyException("CustomScriptArgs", "version");
+        public Builder scriptVersion(String scriptVersion) {
+            if (scriptVersion == null) {
+              throw new MissingRequiredPropertyException("CustomScriptArgs", "scriptVersion");
             }
-            this.version = version;
+            this.scriptVersion = scriptVersion;
             return this;
         }
         public CustomScriptArgs build() {
@@ -121,7 +121,7 @@ public final class CustomScriptArgs {
             _resultValue.attributes = attributes;
             _resultValue.id = id;
             _resultValue.location = location;
-            _resultValue.version = version;
+            _resultValue.scriptVersion = scriptVersion;
             return _resultValue;
         }
     }

--- a/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/outputs/PageCustomCodeScript.java
+++ b/sdk/java/src/main/java/io/github/jdetmar/pulumi/webflow/outputs/PageCustomCodeScript.java
@@ -31,7 +31,7 @@ public final class PageCustomCodeScript {
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      * 
      */
-    private String version;
+    private String scriptVersion;
 
     private PageCustomCodeScript() {}
     /**
@@ -59,8 +59,8 @@ public final class PageCustomCodeScript {
      * @return The semantic version string for the registered script (e.g., &#39;1.0.0&#39;). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      * 
      */
-    public String version() {
-        return this.version;
+    public String scriptVersion() {
+        return this.scriptVersion;
     }
 
     public static Builder builder() {
@@ -75,14 +75,14 @@ public final class PageCustomCodeScript {
         private Map<String,Object> attributes;
         private String id;
         private String location;
-        private String version;
+        private String scriptVersion;
         public Builder() {}
         public Builder(PageCustomCodeScript defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.attributes = defaults.attributes;
     	      this.id = defaults.id;
     	      this.location = defaults.location;
-    	      this.version = defaults.version;
+    	      this.scriptVersion = defaults.scriptVersion;
         }
 
         @CustomType.Setter
@@ -110,11 +110,11 @@ public final class PageCustomCodeScript {
             return this;
         }
         @CustomType.Setter
-        public Builder version(String version) {
-            if (version == null) {
-              throw new MissingRequiredPropertyException("PageCustomCodeScript", "version");
+        public Builder scriptVersion(String scriptVersion) {
+            if (scriptVersion == null) {
+              throw new MissingRequiredPropertyException("PageCustomCodeScript", "scriptVersion");
             }
-            this.version = version;
+            this.scriptVersion = scriptVersion;
             return this;
         }
         public PageCustomCodeScript build() {
@@ -122,7 +122,7 @@ public final class PageCustomCodeScript {
             _resultValue.attributes = attributes;
             _resultValue.id = id;
             _resultValue.location = location;
-            _resultValue.version = version;
+            _resultValue.scriptVersion = scriptVersion;
             return _resultValue;
         }
     }

--- a/sdk/nodejs/inlineScript.ts
+++ b/sdk/nodejs/inlineScript.ts
@@ -63,6 +63,10 @@ export class InlineScript extends pulumi.CustomResource {
      */
     declare public /*out*/ readonly scriptId: pulumi.Output<string>;
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     */
+    declare public readonly scriptVersion: pulumi.Output<string>;
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      */
     declare public readonly siteId: pulumi.Output<string>;
@@ -70,10 +74,6 @@ export class InlineScript extends pulumi.CustomResource {
      * The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
      */
     declare public readonly sourceCode: pulumi.Output<string>;
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     */
-    declare public readonly version: pulumi.Output<string>;
 
     /**
      * Create a InlineScript resource with the given unique name, arguments, and options.
@@ -89,21 +89,21 @@ export class InlineScript extends pulumi.CustomResource {
             if (args?.displayName === undefined && !opts.urn) {
                 throw new Error("Missing required property 'displayName'");
             }
+            if (args?.scriptVersion === undefined && !opts.urn) {
+                throw new Error("Missing required property 'scriptVersion'");
+            }
             if (args?.siteId === undefined && !opts.urn) {
                 throw new Error("Missing required property 'siteId'");
             }
             if (args?.sourceCode === undefined && !opts.urn) {
                 throw new Error("Missing required property 'sourceCode'");
             }
-            if (args?.version === undefined && !opts.urn) {
-                throw new Error("Missing required property 'version'");
-            }
             resourceInputs["canCopy"] = args?.canCopy;
             resourceInputs["displayName"] = args?.displayName;
             resourceInputs["integrityHash"] = args?.integrityHash;
+            resourceInputs["scriptVersion"] = args?.scriptVersion;
             resourceInputs["siteId"] = args?.siteId;
             resourceInputs["sourceCode"] = args?.sourceCode;
-            resourceInputs["version"] = args?.version;
             resourceInputs["createdOn"] = undefined /*out*/;
             resourceInputs["hostedLocation"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
@@ -116,9 +116,9 @@ export class InlineScript extends pulumi.CustomResource {
             resourceInputs["integrityHash"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
             resourceInputs["scriptId"] = undefined /*out*/;
+            resourceInputs["scriptVersion"] = undefined /*out*/;
             resourceInputs["siteId"] = undefined /*out*/;
             resourceInputs["sourceCode"] = undefined /*out*/;
-            resourceInputs["version"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(InlineScript.__pulumiType, name, resourceInputs, opts);
@@ -142,6 +142,10 @@ export interface InlineScriptArgs {
      */
     integrityHash?: pulumi.Input<string>;
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     */
+    scriptVersion: pulumi.Input<string>;
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      */
     siteId: pulumi.Input<string>;
@@ -149,8 +153,4 @@ export interface InlineScriptArgs {
      * The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
      */
     sourceCode: pulumi.Input<string>;
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     */
-    version: pulumi.Input<string>;
 }

--- a/sdk/nodejs/registeredScript.ts
+++ b/sdk/nodejs/registeredScript.ts
@@ -63,13 +63,13 @@ export class RegisteredScript extends pulumi.CustomResource {
      */
     declare public /*out*/ readonly scriptId: pulumi.Output<string>;
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     */
+    declare public readonly scriptVersion: pulumi.Output<string | undefined>;
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      */
     declare public readonly siteId: pulumi.Output<string>;
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     */
-    declare public readonly version: pulumi.Output<string | undefined>;
 
     /**
      * Create a RegisteredScript resource with the given unique name, arguments, and options.
@@ -98,8 +98,8 @@ export class RegisteredScript extends pulumi.CustomResource {
             resourceInputs["displayName"] = args?.displayName;
             resourceInputs["hostedLocation"] = args?.hostedLocation;
             resourceInputs["integrityHash"] = args?.integrityHash;
+            resourceInputs["scriptVersion"] = args?.scriptVersion;
             resourceInputs["siteId"] = args?.siteId;
-            resourceInputs["version"] = args?.version;
             resourceInputs["createdOn"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
             resourceInputs["scriptId"] = undefined /*out*/;
@@ -111,8 +111,8 @@ export class RegisteredScript extends pulumi.CustomResource {
             resourceInputs["integrityHash"] = undefined /*out*/;
             resourceInputs["lastUpdated"] = undefined /*out*/;
             resourceInputs["scriptId"] = undefined /*out*/;
+            resourceInputs["scriptVersion"] = undefined /*out*/;
             resourceInputs["siteId"] = undefined /*out*/;
-            resourceInputs["version"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(RegisteredScript.__pulumiType, name, resourceInputs, opts);
@@ -140,11 +140,11 @@ export interface RegisteredScriptArgs {
      */
     integrityHash: pulumi.Input<string>;
     /**
+     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+     */
+    scriptVersion?: pulumi.Input<string>;
+    /**
      * The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
      */
     siteId: pulumi.Input<string>;
-    /**
-     * The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-     */
-    version?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -21,7 +21,7 @@ export interface CustomScriptArgsArgs {
     /**
      * The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      */
-    version: pulumi.Input<string>;
+    scriptVersion: pulumi.Input<string>;
 }
 
 export interface NodeContentUpdateArgs {
@@ -51,6 +51,6 @@ export interface PageCustomCodeScriptArgs {
     /**
      * The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      */
-    version: pulumi.Input<string>;
+    scriptVersion: pulumi.Input<string>;
 }
 

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -21,7 +21,7 @@ export interface CustomScriptArgs {
     /**
      * The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
      */
-    version: string;
+    scriptVersion: string;
 }
 
 export interface GetTokenInfoApplication {
@@ -116,7 +116,7 @@ export interface PageCustomCodeScript {
     /**
      * The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
      */
-    version: string;
+    scriptVersion: string;
 }
 
 export interface PageInfo {

--- a/sdk/python/pulumi_webflow/_inputs.py
+++ b/sdk/python/pulumi_webflow/_inputs.py
@@ -35,7 +35,7 @@ if not MYPY:
         """
         The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded.
         """
-        version: pulumi.Input[_builtins.str]
+        script_version: pulumi.Input[_builtins.str]
         """
         The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         """
@@ -51,17 +51,17 @@ class CustomScriptArgsArgs:
     def __init__(__self__, *,
                  id: pulumi.Input[_builtins.str],
                  location: pulumi.Input[_builtins.str],
-                 version: pulumi.Input[_builtins.str],
+                 script_version: pulumi.Input[_builtins.str],
                  attributes: Optional[pulumi.Input[Mapping[str, Any]]] = None):
         """
         :param pulumi.Input[_builtins.str] id: The unique identifier of the registered custom code script. The script must first be registered to the site using the RegisterScript resource. Examples: 'cms_slider', 'analytics', 'custom_widget'
         :param pulumi.Input[_builtins.str] location: The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded.
-        :param pulumi.Input[_builtins.str] version: The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
+        :param pulumi.Input[_builtins.str] script_version: The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         :param pulumi.Input[Mapping[str, Any]] attributes: Optional developer-specified key/value pairs applied as HTML attributes to the script tag. Example: {'data-config': 'my-value'}. These attributes are passed directly to the script tag.
         """
         pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "location", location)
-        pulumi.set(__self__, "version", version)
+        pulumi.set(__self__, "script_version", script_version)
         if attributes is not None:
             pulumi.set(__self__, "attributes", attributes)
 
@@ -90,16 +90,16 @@ class CustomScriptArgsArgs:
         pulumi.set(self, "location", value)
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Input[_builtins.str]:
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> pulumi.Input[_builtins.str]:
         """
         The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         """
-        return pulumi.get(self, "version")
+        return pulumi.get(self, "script_version")
 
-    @version.setter
-    def version(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "version", value)
+    @script_version.setter
+    def script_version(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "script_version", value)
 
     @_builtins.property
     @pulumi.getter
@@ -178,7 +178,7 @@ if not MYPY:
         """
         Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded.
         """
-        version: pulumi.Input[_builtins.str]
+        script_version: pulumi.Input[_builtins.str]
         """
         The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         """
@@ -191,17 +191,17 @@ class PageCustomCodeScriptArgs:
                  attributes: pulumi.Input[Mapping[str, Any]],
                  id: pulumi.Input[_builtins.str],
                  location: pulumi.Input[_builtins.str],
-                 version: pulumi.Input[_builtins.str]):
+                 script_version: pulumi.Input[_builtins.str]):
         """
         :param pulumi.Input[Mapping[str, Any]] attributes: Optional developer-specified key/value pairs for script attributes. These attributes can be used by the script to customize its behavior on this page.
         :param pulumi.Input[_builtins.str] id: The unique identifier of a registered custom code script. This must be a script that was previously registered using the RegisteredScript resource. Script IDs are assigned by Webflow when the script is registered.
         :param pulumi.Input[_builtins.str] location: Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded.
-        :param pulumi.Input[_builtins.str] version: The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
+        :param pulumi.Input[_builtins.str] script_version: The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         """
         pulumi.set(__self__, "attributes", attributes)
         pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "location", location)
-        pulumi.set(__self__, "version", version)
+        pulumi.set(__self__, "script_version", script_version)
 
     @_builtins.property
     @pulumi.getter
@@ -240,15 +240,15 @@ class PageCustomCodeScriptArgs:
         pulumi.set(self, "location", value)
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Input[_builtins.str]:
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> pulumi.Input[_builtins.str]:
         """
         The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         """
-        return pulumi.get(self, "version")
+        return pulumi.get(self, "script_version")
 
-    @version.setter
-    def version(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "version", value)
+    @script_version.setter
+    def script_version(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "script_version", value)
 
 

--- a/sdk/python/pulumi_webflow/inline_script.py
+++ b/sdk/python/pulumi_webflow/inline_script.py
@@ -20,24 +20,24 @@ __all__ = ['InlineScriptArgs', 'InlineScript']
 class InlineScriptArgs:
     def __init__(__self__, *,
                  display_name: pulumi.Input[_builtins.str],
+                 script_version: pulumi.Input[_builtins.str],
                  site_id: pulumi.Input[_builtins.str],
                  source_code: pulumi.Input[_builtins.str],
-                 version: pulumi.Input[_builtins.str],
                  can_copy: Optional[pulumi.Input[_builtins.bool]] = None,
                  integrity_hash: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a InlineScript resource.
         :param pulumi.Input[_builtins.str] display_name: The user-facing name for the script (1-50 alphanumeric characters). This name is used to identify the script in the Webflow interface. Only letters (A-Z, a-z) and numbers (0-9) are allowed. Example valid names: 'CmsSlider', 'AnalyticsScript', 'MyCustomScript123'.
+        :param pulumi.Input[_builtins.str] script_version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         :param pulumi.Input[_builtins.str] site_id: The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         :param pulumi.Input[_builtins.str] source_code: The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
-        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         :param pulumi.Input[_builtins.bool] can_copy: Indicates whether the script can be copied when the site is duplicated. Default: false. When true, the script will be included when creating a copy of the site.
         :param pulumi.Input[_builtins.str] integrity_hash: The Sub-Resource Integrity (SRI) hash for the script (optional). Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
         """
         pulumi.set(__self__, "display_name", display_name)
+        pulumi.set(__self__, "script_version", script_version)
         pulumi.set(__self__, "site_id", site_id)
         pulumi.set(__self__, "source_code", source_code)
-        pulumi.set(__self__, "version", version)
         if can_copy is not None:
             pulumi.set(__self__, "can_copy", can_copy)
         if integrity_hash is not None:
@@ -54,6 +54,18 @@ class InlineScriptArgs:
     @display_name.setter
     def display_name(self, value: pulumi.Input[_builtins.str]):
         pulumi.set(self, "display_name", value)
+
+    @_builtins.property
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> pulumi.Input[_builtins.str]:
+        """
+        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        """
+        return pulumi.get(self, "script_version")
+
+    @script_version.setter
+    def script_version(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "script_version", value)
 
     @_builtins.property
     @pulumi.getter(name="siteId")
@@ -78,18 +90,6 @@ class InlineScriptArgs:
     @source_code.setter
     def source_code(self, value: pulumi.Input[_builtins.str]):
         pulumi.set(self, "source_code", value)
-
-    @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Input[_builtins.str]:
-        """
-        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        """
-        return pulumi.get(self, "version")
-
-    @version.setter
-    def version(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "version", value)
 
     @_builtins.property
     @pulumi.getter(name="canCopy")
@@ -125,9 +125,9 @@ class InlineScript(pulumi.CustomResource):
                  can_copy: Optional[pulumi.Input[_builtins.bool]] = None,
                  display_name: Optional[pulumi.Input[_builtins.str]] = None,
                  integrity_hash: Optional[pulumi.Input[_builtins.str]] = None,
+                 script_version: Optional[pulumi.Input[_builtins.str]] = None,
                  site_id: Optional[pulumi.Input[_builtins.str]] = None,
                  source_code: Optional[pulumi.Input[_builtins.str]] = None,
-                 version: Optional[pulumi.Input[_builtins.str]] = None,
                  __props__=None):
         """
         Manages inline custom code scripts in the Webflow script registry. This resource allows you to register and manage inline JavaScript code that can be deployed across your Webflow site with version control.
@@ -137,9 +137,9 @@ class InlineScript(pulumi.CustomResource):
         :param pulumi.Input[_builtins.bool] can_copy: Indicates whether the script can be copied when the site is duplicated. Default: false. When true, the script will be included when creating a copy of the site.
         :param pulumi.Input[_builtins.str] display_name: The user-facing name for the script (1-50 alphanumeric characters). This name is used to identify the script in the Webflow interface. Only letters (A-Z, a-z) and numbers (0-9) are allowed. Example valid names: 'CmsSlider', 'AnalyticsScript', 'MyCustomScript123'.
         :param pulumi.Input[_builtins.str] integrity_hash: The Sub-Resource Integrity (SRI) hash for the script (optional). Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
+        :param pulumi.Input[_builtins.str] script_version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         :param pulumi.Input[_builtins.str] site_id: The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         :param pulumi.Input[_builtins.str] source_code: The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
-        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """
         ...
     @overload
@@ -168,9 +168,9 @@ class InlineScript(pulumi.CustomResource):
                  can_copy: Optional[pulumi.Input[_builtins.bool]] = None,
                  display_name: Optional[pulumi.Input[_builtins.str]] = None,
                  integrity_hash: Optional[pulumi.Input[_builtins.str]] = None,
+                 script_version: Optional[pulumi.Input[_builtins.str]] = None,
                  site_id: Optional[pulumi.Input[_builtins.str]] = None,
                  source_code: Optional[pulumi.Input[_builtins.str]] = None,
-                 version: Optional[pulumi.Input[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -185,15 +185,15 @@ class InlineScript(pulumi.CustomResource):
                 raise TypeError("Missing required property 'display_name'")
             __props__.__dict__["display_name"] = display_name
             __props__.__dict__["integrity_hash"] = integrity_hash
+            if script_version is None and not opts.urn:
+                raise TypeError("Missing required property 'script_version'")
+            __props__.__dict__["script_version"] = script_version
             if site_id is None and not opts.urn:
                 raise TypeError("Missing required property 'site_id'")
             __props__.__dict__["site_id"] = site_id
             if source_code is None and not opts.urn:
                 raise TypeError("Missing required property 'source_code'")
             __props__.__dict__["source_code"] = source_code
-            if version is None and not opts.urn:
-                raise TypeError("Missing required property 'version'")
-            __props__.__dict__["version"] = version
             __props__.__dict__["created_on"] = None
             __props__.__dict__["hosted_location"] = None
             __props__.__dict__["last_updated"] = None
@@ -227,9 +227,9 @@ class InlineScript(pulumi.CustomResource):
         __props__.__dict__["integrity_hash"] = None
         __props__.__dict__["last_updated"] = None
         __props__.__dict__["script_id"] = None
+        __props__.__dict__["script_version"] = None
         __props__.__dict__["site_id"] = None
         __props__.__dict__["source_code"] = None
-        __props__.__dict__["version"] = None
         return InlineScript(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
@@ -289,6 +289,14 @@ class InlineScript(pulumi.CustomResource):
         return pulumi.get(self, "script_id")
 
     @_builtins.property
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> pulumi.Output[_builtins.str]:
+        """
+        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        """
+        return pulumi.get(self, "script_version")
+
+    @_builtins.property
     @pulumi.getter(name="siteId")
     def site_id(self) -> pulumi.Output[_builtins.str]:
         """
@@ -303,12 +311,4 @@ class InlineScript(pulumi.CustomResource):
         The inline JavaScript code to register, limited to 2000 characters. This code will be directly embedded in your Webflow site. If your script exceeds 2000 characters, consider hosting it externally and using the RegisteredScript resource with a hostedLocation instead.
         """
         return pulumi.get(self, "source_code")
-
-    @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Output[_builtins.str]:
-        """
-        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        """
-        return pulumi.get(self, "version")
 

--- a/sdk/python/pulumi_webflow/outputs.py
+++ b/sdk/python/pulumi_webflow/outputs.py
@@ -27,20 +27,37 @@ __all__ = [
 
 @pulumi.output_type
 class CustomScriptArgs(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "scriptVersion":
+            suggest = "script_version"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in CustomScriptArgs. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        CustomScriptArgs.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        CustomScriptArgs.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  id: _builtins.str,
                  location: _builtins.str,
-                 version: _builtins.str,
+                 script_version: _builtins.str,
                  attributes: Optional[Mapping[str, Any]] = None):
         """
         :param _builtins.str id: The unique identifier of the registered custom code script. The script must first be registered to the site using the RegisterScript resource. Examples: 'cms_slider', 'analytics', 'custom_widget'
         :param _builtins.str location: The location where the script is placed on the page. Valid values: 'header' (placed in the <head> section), 'footer' (placed before </body>). Scripts in the header execute before page content loads, while footer scripts execute after the page has loaded.
-        :param _builtins.str version: The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
+        :param _builtins.str script_version: The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         :param Mapping[str, Any] attributes: Optional developer-specified key/value pairs applied as HTML attributes to the script tag. Example: {'data-config': 'my-value'}. These attributes are passed directly to the script tag.
         """
         pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "location", location)
-        pulumi.set(__self__, "version", version)
+        pulumi.set(__self__, "script_version", script_version)
         if attributes is not None:
             pulumi.set(__self__, "attributes", attributes)
 
@@ -61,12 +78,12 @@ class CustomScriptArgs(dict):
         return pulumi.get(self, "location")
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> _builtins.str:
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> _builtins.str:
         """
         The semantic version string for the registered script (e.g., '1.0.0', '0.1.2'). This version must exist for the registered script ID. When you update the version, a different version of the script will be applied.
         """
-        return pulumi.get(self, "version")
+        return pulumi.get(self, "script_version")
 
     @_builtins.property
     @pulumi.getter
@@ -300,21 +317,38 @@ class NodeContentUpdate(dict):
 
 @pulumi.output_type
 class PageCustomCodeScript(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "scriptVersion":
+            suggest = "script_version"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in PageCustomCodeScript. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        PageCustomCodeScript.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        PageCustomCodeScript.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  attributes: Mapping[str, Any],
                  id: _builtins.str,
                  location: _builtins.str,
-                 version: _builtins.str):
+                 script_version: _builtins.str):
         """
         :param Mapping[str, Any] attributes: Optional developer-specified key/value pairs for script attributes. These attributes can be used by the script to customize its behavior on this page.
         :param _builtins.str id: The unique identifier of a registered custom code script. This must be a script that was previously registered using the RegisteredScript resource. Script IDs are assigned by Webflow when the script is registered.
         :param _builtins.str location: Where the script should be applied on the page. Must be either 'header' (loaded in page header) or 'footer' (loaded at end of page). Use 'header' for scripts that don't depend on DOM elements. Use 'footer' for scripts that need to run after DOM is fully loaded.
-        :param _builtins.str version: The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
+        :param _builtins.str script_version: The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         """
         pulumi.set(__self__, "attributes", attributes)
         pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "location", location)
-        pulumi.set(__self__, "version", version)
+        pulumi.set(__self__, "script_version", script_version)
 
     @_builtins.property
     @pulumi.getter
@@ -341,12 +375,12 @@ class PageCustomCodeScript(dict):
         return pulumi.get(self, "location")
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> _builtins.str:
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> _builtins.str:
         """
         The semantic version string for the registered script (e.g., '1.0.0'). This version must match a registered version of the script. You can have multiple versions of the same script registered.
         """
-        return pulumi.get(self, "version")
+        return pulumi.get(self, "script_version")
 
 
 @pulumi.output_type

--- a/sdk/python/pulumi_webflow/registered_script.py
+++ b/sdk/python/pulumi_webflow/registered_script.py
@@ -24,7 +24,7 @@ class RegisteredScriptArgs:
                  integrity_hash: pulumi.Input[_builtins.str],
                  site_id: pulumi.Input[_builtins.str],
                  can_copy: Optional[pulumi.Input[_builtins.bool]] = None,
-                 version: Optional[pulumi.Input[_builtins.str]] = None):
+                 script_version: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a RegisteredScript resource.
         :param pulumi.Input[_builtins.str] display_name: The user-facing name for the script (1-50 alphanumeric characters). This name is used to identify the script in the Webflow interface. Only letters (A-Z, a-z) and numbers (0-9) are allowed. Example valid names: 'CmsSlider', 'AnalyticsScript', 'MyCustomScript123'.
@@ -32,7 +32,7 @@ class RegisteredScriptArgs:
         :param pulumi.Input[_builtins.str] integrity_hash: The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
         :param pulumi.Input[_builtins.str] site_id: The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         :param pulumi.Input[_builtins.bool] can_copy: Indicates whether the script can be copied when the site is duplicated. Default: false. When true, the script will be included when creating a copy of the site.
-        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        :param pulumi.Input[_builtins.str] script_version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """
         pulumi.set(__self__, "display_name", display_name)
         pulumi.set(__self__, "hosted_location", hosted_location)
@@ -40,8 +40,8 @@ class RegisteredScriptArgs:
         pulumi.set(__self__, "site_id", site_id)
         if can_copy is not None:
             pulumi.set(__self__, "can_copy", can_copy)
-        if version is not None:
-            pulumi.set(__self__, "version", version)
+        if script_version is not None:
+            pulumi.set(__self__, "script_version", script_version)
 
     @_builtins.property
     @pulumi.getter(name="displayName")
@@ -104,16 +104,16 @@ class RegisteredScriptArgs:
         pulumi.set(self, "can_copy", value)
 
     @_builtins.property
-    @pulumi.getter
-    def version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> Optional[pulumi.Input[_builtins.str]]:
         """
         The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """
-        return pulumi.get(self, "version")
+        return pulumi.get(self, "script_version")
 
-    @version.setter
-    def version(self, value: Optional[pulumi.Input[_builtins.str]]):
-        pulumi.set(self, "version", value)
+    @script_version.setter
+    def script_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+        pulumi.set(self, "script_version", value)
 
 
 @pulumi.type_token("webflow:index:RegisteredScript")
@@ -126,8 +126,8 @@ class RegisteredScript(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[_builtins.str]] = None,
                  hosted_location: Optional[pulumi.Input[_builtins.str]] = None,
                  integrity_hash: Optional[pulumi.Input[_builtins.str]] = None,
+                 script_version: Optional[pulumi.Input[_builtins.str]] = None,
                  site_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 version: Optional[pulumi.Input[_builtins.str]] = None,
                  __props__=None):
         """
         Manages custom code scripts in the Webflow script registry. This resource allows you to register and manage externally hosted scripts that can be deployed across your Webflow site with version control and integrity verification.
@@ -138,8 +138,8 @@ class RegisteredScript(pulumi.CustomResource):
         :param pulumi.Input[_builtins.str] display_name: The user-facing name for the script (1-50 alphanumeric characters). This name is used to identify the script in the Webflow interface. Only letters (A-Z, a-z) and numbers (0-9) are allowed. Example valid names: 'CmsSlider', 'AnalyticsScript', 'MyCustomScript123'.
         :param pulumi.Input[_builtins.str] hosted_location: The URI for the externally hosted script (e.g., 'https://cdn.example.com/my-script.js'). Must be a valid HTTP or HTTPS URL. The script should be publicly accessible and properly configured for cross-origin requests.
         :param pulumi.Input[_builtins.str] integrity_hash: The Sub-Resource Integrity (SRI) hash for the script. Format: 'sha384-<hash>', 'sha256-<hash>', or 'sha512-<hash>'. SRI hashes help ensure that the script hasn't been modified in transit. You can generate an SRI hash using https://www.srihash.org/
+        :param pulumi.Input[_builtins.str] script_version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         :param pulumi.Input[_builtins.str] site_id: The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
-        :param pulumi.Input[_builtins.str] version: The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
         """
         ...
     @overload
@@ -169,8 +169,8 @@ class RegisteredScript(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[_builtins.str]] = None,
                  hosted_location: Optional[pulumi.Input[_builtins.str]] = None,
                  integrity_hash: Optional[pulumi.Input[_builtins.str]] = None,
+                 script_version: Optional[pulumi.Input[_builtins.str]] = None,
                  site_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 version: Optional[pulumi.Input[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -190,10 +190,10 @@ class RegisteredScript(pulumi.CustomResource):
             if integrity_hash is None and not opts.urn:
                 raise TypeError("Missing required property 'integrity_hash'")
             __props__.__dict__["integrity_hash"] = integrity_hash
+            __props__.__dict__["script_version"] = script_version
             if site_id is None and not opts.urn:
                 raise TypeError("Missing required property 'site_id'")
             __props__.__dict__["site_id"] = site_id
-            __props__.__dict__["version"] = version
             __props__.__dict__["created_on"] = None
             __props__.__dict__["last_updated"] = None
             __props__.__dict__["script_id"] = None
@@ -226,8 +226,8 @@ class RegisteredScript(pulumi.CustomResource):
         __props__.__dict__["integrity_hash"] = None
         __props__.__dict__["last_updated"] = None
         __props__.__dict__["script_id"] = None
+        __props__.__dict__["script_version"] = None
         __props__.__dict__["site_id"] = None
-        __props__.__dict__["version"] = None
         return RegisteredScript(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
@@ -287,18 +287,18 @@ class RegisteredScript(pulumi.CustomResource):
         return pulumi.get(self, "script_id")
 
     @_builtins.property
+    @pulumi.getter(name="scriptVersion")
+    def script_version(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
+        """
+        return pulumi.get(self, "script_version")
+
+    @_builtins.property
     @pulumi.getter(name="siteId")
     def site_id(self) -> pulumi.Output[_builtins.str]:
         """
         The Webflow site ID (24-character lowercase hexadecimal string, e.g., '5f0c8c9e1c9d440000e8d8c3'). You can find your site ID in the Webflow dashboard under Site Settings. This field will be validated before making any API calls.
         """
         return pulumi.get(self, "site_id")
-
-    @_builtins.property
-    @pulumi.getter
-    def version(self) -> pulumi.Output[Optional[_builtins.str]]:
-        """
-        The Semantic Version (SemVer) string for the script (e.g., '1.0.0', '2.3.1'). This helps track different versions of your script. See https://semver.org/ for more information on semantic versioning.
-        """
-        return pulumi.get(self, "version")
 


### PR DESCRIPTION
## Summary

- Rename the `version` Pulumi property to `scriptVersion` across all script-related resources (InlineScript, RegisteredScript, SiteCustomCode, PageCustomCode)
- The `pulumi-go-provider` `infer` framework strips any property named `"version"` from resource inputs during Diff, treating it as an internal Pulumi engine property
- This caused InlineScript to fail with `Missing required field 'version'` and silently broke version change detection in all script resources

## Breaking Change

The `version` property is renamed to `scriptVersion` in:
- `InlineScript` / `RegisteredScript` resource args
- `SiteCustomCode` script args (`CustomScriptArgs`)
- `PageCustomCode` script args (`PageCustomCodeScript`)

Users must update their Pulumi programs (e.g., `Version` → `ScriptVersion` in C#, `version` → `scriptVersion` in TypeScript/Python).

## Test plan

- [x] `make codegen` — schema and all 5 SDKs regenerated
- [x] `make lint` — 0 issues
- [x] `make test_provider` — 440/440 tests pass
- [x] Verified no remaining `pulumi:"version"` tags in provider code

🤖 Generated with [Claude Code](https://claude.com/claude-code)